### PR TITLE
Need git-clone-url defined

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -21,4 +21,5 @@
 
     # GitHub configuration
     git-url: https://github.com
+    git-clone-url: 'git@github.com:'
     github-org: edgexfoundry


### PR DESCRIPTION
The updated global-jjb needs a new default added of git-clone-url with
sets the root clone string

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>