### PR TITLE
Add jobs for core java projects

### DIFF
--- a/jjb/core/core-command-client.yaml
+++ b/jjb/core/core-command-client.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-command-client
+    project-name: core-command-client
+    project: core-command-client
+    mvn-settings: core-command-client-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-command.yaml
+++ b/jjb/core/core-command.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-command
+    project-name: core-command
+    project: core-command
+    mvn-settings: core-command-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-config-seed.yaml
+++ b/jjb/core/core-config-seed.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-config-seed
+    project-name: core-config-seed
+    project: core-config-seed
+    mvn-settings: core-config-seed-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-config-watcher.yaml
+++ b/jjb/core/core-config-watcher.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-config-watcher
+    project-name: core-config-watcher
+    project: core-config-watcher
+    mvn-settings: core-config-watcher-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-data-client.yaml
+++ b/jjb/core/core-data-client.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-data-client
+    project-name: core-data-client
+    project: core-data-client
+    mvn-settings: core-data-client-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-data.yaml
+++ b/jjb/core/core-data.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-data
+    project-name: core-data
+    project: core-data
+    mvn-settings: core-data-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-domain.yaml
+++ b/jjb/core/core-domain.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-domain
+    project-name: core-domain
+    project: core-domain
+    mvn-settings: core-domain-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-exception.yaml
+++ b/jjb/core/core-exception.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-exception
+    project-name: core-exception
+    project: core-exception
+    mvn-settings: core-exception-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-metadata-client.yaml
+++ b/jjb/core/core-metadata-client.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-metadata-client
+    project-name: core-metadata-client
+    project: core-metadata-client
+    mvn-settings: core-metadata-client-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-metadata.yaml
+++ b/jjb/core/core-metadata.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-metadata
+    project-name: core-metadata
+    project: core-metadata
+    mvn-settings: core-metadata-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/core/core-test.yaml
+++ b/jjb/core/core-test.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: core-test
+    project-name: core-test
+    project: core-test
+    mvn-settings: core-test-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'


### PR DESCRIPTION
Add verify and merge jobs for all of the core* java projects identified
by looking for projects that have a top-level pom.xml file.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>