### PR TITLE
Add jobs for device java projects

### DIFF
--- a/jjb/device/device-sdk-tools.yaml
+++ b/jjb/device/device-sdk-tools.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: device-sdk-tools
+    project-name: device-sdk-tools
+    project: device-sdk-tools
+    mvn-settings: device-sdk-tools-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/device/device-sdk.yaml
+++ b/jjb/device/device-sdk.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: device-sdk
+    project-name: device-sdk
+    project: device-sdk
+    mvn-settings: device-sdk-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/device/device-virtual.yaml
+++ b/jjb/device/device-virtual.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: device-virtual
+    project-name: device-virtual
+    project: device-virtual
+    mvn-settings: device-virtual-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'


### PR DESCRIPTION
Add verify and merge jobs for all of the device* java projects
identified by looking for projects that have a top-level pom.xml file.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>