### PR TITLE
Fix the GitHub project URL

### DIFF
--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -22,7 +22,7 @@
           project: '{project}'
           build-days-to-keep: '{build-days-to-keep}'
       - github:
-          url: '{git-url}{github-org}/{project}'
+          url: '{git-url}/{github-org}/{project}'
 
     parameters:
       - lf-infra-parameters:


### PR DESCRIPTION
The GitHub project URL used by Jenkins is missing a separating '/'
character.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>