### PR TITLE
Add jobs for support java projects

### DIFF
--- a/jjb/support/support-domain.yaml
+++ b/jjb/support/support-domain.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: support-domain
+    project-name: support-domain
+    project: support-domain
+    mvn-settings: support-domain-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/support/support-logging-client.yaml
+++ b/jjb/support/support-logging-client.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: support-logging-client
+    project-name: support-logging-client
+    project: support-logging-client
+    mvn-settings: support-logging-client-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/support/support-logging.yaml
+++ b/jjb/support/support-logging.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: support-logging
+    project-name: support-logging
+    project: support-logging
+    mvn-settings: support-logging-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/support/support-notifications-client.yaml
+++ b/jjb/support/support-notifications-client.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: support-notifications-client
+    project-name: support-notifications-client
+    project: support-notifications-client
+    mvn-settings: support-notifications-client-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/support/support-notifications.yaml
+++ b/jjb/support/support-notifications.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: support-notifications
+    project-name: support-notifications
+    project: support-notifications
+    mvn-settings: support-notifications-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/support/support-rulesengine.yaml
+++ b/jjb/support/support-rulesengine.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: support-rulesengine
+    project-name: support-rulesengine
+    project: support-rulesengine
+    mvn-settings: support-rulesengine-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'

--- a/jjb/support/support-scheduler.yaml
+++ b/jjb/support/support-scheduler.yaml
@@ -1,0 +1,14 @@
+---
+
+- project:
+    name: support-scheduler
+    project-name: support-scheduler
+    project: support-scheduler
+    mvn-settings: support-scheduler-settings
+    archive-artifacts: ''
+    stream:
+      - 'master'
+
+    jobs:
+      - '{project-name}-{stream}-verify-java'
+      - '{project-name}-{stream}-merge-java'


### PR DESCRIPTION
Add verify and merge jobs for all of the support* java projects
identified by looking at projects that have a top-level pom.xml and are
not titled docker-

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>