### PR TITLE
Fix export-test jobs

### DIFF
--- a/jjb/export/export-test.yaml
+++ b/jjb/export/export-test.yaml
@@ -1,10 +1,10 @@
 ---
 
 - project:
-    name: export-export-test
-    project-name: export-export-test
-    project: export-export-test
-    mvn-settings: export-export-test-settings
+    name: export-test
+    project-name: export-test
+    project: export-test
+    mvn-settings: export-test-settings
     archive-artifacts: ''
     stream:
       - 'master'


### PR DESCRIPTION
While creating the jobs for export-test the name got an extra export-
prefix added.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>