### PR TITLE
Update global-jjb to 0.4.3 and GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jjb/global-jjb"]
 	path = jjb/global-jjb
-	url = https://gerrit.linuxfoundation.org/infra/releng/global-jjb
+	url = https://github.com/lfit/releng-global-jjb


### PR DESCRIPTION
The Linux Foundation has started to mirror global-jjb to GitHub. As
such, it's a good idea to switch the submodule to use this repo instead
of the source Gerrit as it de-couples JJB management from the upstream
repo allowing us to do maintenance when we need to without coordinating
with all projects.

Secondly, there have been several updates to global-jjb so it's time to
pull in the latest changes as well.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>