### PR TITLE
Fix called packer templates

### DIFF
--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -9,7 +9,7 @@
             - docker
           os-cloud-file-id: 'packer-cloud-env'
           platforms:
-            - centos
+            - centos-7
 
     name: ci-management-jobs
     project: ci-management


### PR DESCRIPTION
The packer templates where being called for centos and not centos-7
which means that when the packer merge job tried to build it failed to
since the json file with the settings is named centos-7

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>