### PR TITLE
Add docker verify and merge job templates

### DIFF
--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -10,6 +10,12 @@
           os-cloud-file-id: 'packer-cloud-env'
           platforms:
             - centos-7
+      - '{project-name}-{stream}-verify-docker':
+          stream: master
+          mvn-settings: global-settings
+      - '{project-name}-{stream}-merge-docker':
+          stream: master
+          mvn-settings: global-settings
 
     name: ci-management-jobs
     project: ci-management

--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -1,0 +1,167 @@
+---
+###########
+# ANCHORS #
+###########
+- docker_job_boiler_plate: &docker_job_boiler_plate
+    name: docker_job-boiler-plate
+
+    project-type: freestyle
+    node: '{build-node}'
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+    submodule-recursive: true
+
+    # default params for docker jobs
+    pre_build_script: ''
+    post_build_script: ''
+    docker_root: '$WORKSPACE'
+    docker_build_args: ''
+    docker_name: 'unnamed'
+    # Default to LF standard 'snapshots' docker registry
+    docker_registry: '$DOCKER_REGISTRY:10003'
+    docker_tag: 'latest'
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    properties:
+      - lf-infra-properties:
+          build-days-to-keep: '{build-days-to-keep}'
+      - github:
+          url: '{git-url}/{github-org}/{project}'
+
+    parameters:
+      - lf-infra-parameters:
+          branch: '{branch}'
+          project: '{project}'
+          stream: '{stream}'
+
+    wrappers:
+      - lf-infra-wrappers:
+          build-timeout: '{build-timeout}'
+          jenkins-ssh-credential: '{jenkins-ssh-credential}'
+
+    publishers:
+      - lf-infra-publish
+
+- docker_verify_boiler_plate: &docker_verify_boiler_plate
+    name: docker_verify_boiler_plate
+
+    concurrent: true
+
+    scm:
+      - lf-infra-github-scm:
+          url: '{git-clone-url}{github-org}/{project}'
+          refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+          branch: '{branch}'
+          submodule-recursive: '{submodule-recursive}'
+          choosing-strategy: default
+          jenkins-ssh-credential: '{jenkins-ssh-credential}'
+
+    triggers:
+      - github-pull-request:
+          trigger-phrase: '^recheck$'
+          only-trigger-phrase: false
+          status-context: '{project} Verify'
+          permit-all: true
+          github-hooks: true
+          auto-close-on-fail: false
+
+- docker_merge_boiler_plate: &docker_merge_boiler_plate
+    name: docker_merge_boiler_plate
+
+    scm:
+      - lf-infra-github-scm:
+          url: '{git-clone-url}{github-org}/{project}'
+          refspec: ''
+          branch: '{branch}'
+          submodule-recursive: '{submodule-recursive}'
+          choosing-strategy: default
+          jenkins-ssh-credential: '{jenkins-ssh-credential}'
+
+    triggers:
+      # no reason to add lf-infra-github-pr-trigger here since it doesn't
+      # currently work for merge / push
+      - github
+      - pollscm:
+          cron: ''
+
+#################
+# JOB TEMPLATES #
+#################
+- job-template:
+    name: '{project-name}-{stream}-merge-docker'
+    # Job template for Docker merge jobs
+    #
+    # The purpose of this job template is to run a docker build, and potentially
+    # test validation of the docker image
+
+    <<: *docker_job_boiler_plate
+    # yamllint disable-line rule:key-duplicates
+    <<: *docker_merge_boiler_plate
+
+    builders:
+      - lf-infra-docker-login:
+          global-settings-file: 'global-settings'
+          settings-file: '{mvn-settings}'
+      - shell: '{pre_build_script}'
+      - inject:
+          # Docker registry is purposely not using an '_' so as to not conflict
+          # with the Jenkins global env var
+          properties-content: |
+            DOCKER_ARGS={docker_build_args}
+            DOCKER_NAME={docker_name}
+            DOCKER_ROOT={docker_root}
+            DOCKER_TAG={docker_tag}
+            DOCKERREGISTRY={docker_registry}
+      # Do the docker build
+      - shell: !include-raw: ../shell/docker-build.sh
+      - inject:
+          # Import the docker image information from the build step
+          properties-file: 'env_inject.txt'
+      # Execute any post build clean-up or testing
+      - shell: '{post_build_script}'
+      # Provided all steps have already passed, push the docker image
+      - shell: !include-raw: ../shell/docker-push.sh
+
+- job-template:
+    name: '{project-name}-{stream}-verify-docker'
+    # Job template for Docker verify jobs
+    #
+    # The purpose of this job template is to run a docker build, and potentially
+    # test validation of the docker image
+
+    ######################
+    # Default parameters #
+    ######################
+
+    <<: *docker_job_boiler_plate
+    # yamllint disable-line rule:key-duplicates
+    <<: *docker_verify_boiler_plate
+
+    builders:
+      - lf-infra-docker-login:
+          global-settings-file: 'global-settings'
+          settings-file: '{mvn-settings}'
+      - shell: '{pre_build_script}'
+      - inject:
+          # Docker registry is purposely not using an '_' so as to not conflict
+          # with the Jenkins global env var
+          properties-content: |
+            DOCKER_ARGS={docker_build_args}
+            DOCKER_NAME={docker_name}
+            DOCKER_ROOT={docker_root}
+            DOCKER_TAG={docker_tag}
+            DOCKERREGISTRY={docker_registry}
+      # Do the docker build
+      - shell: !include-raw: ../shell/docker-build.sh
+      - inject:
+          # Import the docker image information from the build step
+          properties-file: 'env_inject.txt'
+      # Execute any post build clean-up or testing
+      - shell: '{post_build_script}'

--- a/shell/docker-build.sh
+++ b/shell/docker-build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Ensure we fail the job if any steps fail
+# Do not set -u as DOCKER_ARGS may be unbound
+set -e -o pipefail
+
+# Switch to the directory where the Dockerfile is
+cd "$DOCKER_ROOT"
+
+# Build the docker image
+
+# Allow word splitting
+# shellcheck disable=SC2086
+docker build $DOCKER_ARGS . | tee "$WORKSPACE/docker_build_log.txt"
+DOCKER_IMAGE=$(grep -Po 'Successfully built \K[^ ]+' \
+    "$WORKSPACE/docker_build_log.txt")
+
+# DOCKERREGISTRY is purposely not using an '_' so as to not conflict with the
+# Jenkins global env var of the DOCKER_REGISTRY which the docker-login step uses
+IMAGE_NAME="$DOCKERREGISTRY/$DOCKER_NAME:$DOCKER_TAG"
+
+docker tag "$DOCKER_IMAGE" "$IMAGE_NAME"
+
+# Write DOCKER_IMAGE information to a file so it can be injected into the
+# environment for following steps
+echo "DOCKER_IMAGE=$IMAGE_NAME" >> "$WORKSPACE/env_inject.txt"
+

--- a/shell/docker-push.sh
+++ b/shell/docker-push.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Ensure we fail the job if any steps fail
+set -e -o pipefail
+
+# Push our image to wherever it's defined to go by the name
+docker push "$DOCKER_IMAGE"


### PR DESCRIPTION
Adds templates for doing verify and merge of docker components.

* Job templates allow for pre-build script to be passed to the job
* Job templates allow for post-build script to be passed to the job
* Post-build script is executed before the push to the local docker
  registry in merge template

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>