### PR TITLE
Namespace status-context in templates

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -68,7 +68,7 @@
       - github-pull-request:
           trigger-phrase: '^recheck$'
           only-trigger-phrase: false
-          status-context: '{project} Verify'
+          status-context: '{project}-Docker-Verify'
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false

--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -57,7 +57,7 @@
       - github-pull-request:
           trigger-phrase: '^recheck$'
           only-trigger-phrase: false
-          status-context: '{project} Verify'
+          status-context: '{project}-Java-Verify'
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false


### PR DESCRIPTION
Update namespace to include Docker or
Java depending on which template they belong
to.  This is needed because it is hard to
determine which status is reporting on GitHub.

JIRA: RELENG-467
Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>