### PR TITLE
Add reverse triggers for docker jobs

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -91,6 +91,8 @@
       - github
       - pollscm:
           cron: ''
+      - reverse:
+          jobs: '{project-name}-{stream}-merge-java'
 
 #################
 # JOB TEMPLATES #
@@ -214,4 +216,5 @@
       - shell: !include-raw: ../shell/docker-push.sh
 
     triggers:
-      - timed: 'H 11 * * *'
+      - reverse:
+          jobs: '{project-name}-{stream}-release-version-java-daily-no-sonar'


### PR DESCRIPTION
This will serialize the flow artifacts
from java merge jobs to docker jobs.

JIRA: RELENG-468
Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>