### PR TITLE
Serialize java merge and docker merge

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -132,6 +132,11 @@
       # Provided all steps have already passed, push the docker image
       - shell: !include-raw: ../shell/docker-push.sh
 
+    # Doesn't make sense to build unless there are new artifacts released
+    triggers:
+      - reverse:
+          jobs: '{project-name}-{stream}-merge-java'
+
 - job-template:
     name: '{project-name}-{stream}-verify-docker'
     # Job template for Docker verify jobs


### PR DESCRIPTION
This will alleviate the issue we have when bumping
versions in pom's of projects that also have a pom
in the docker directory.  The java artifacts don't exist
yet for inclusion in the container if docker merge and java
merge run simultaneously.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>