### PR TITLE
Fix verify to pick any branch

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -59,7 +59,7 @@
       - lf-infra-github-scm:
           url: '{git-clone-url}{github-org}/{project}'
           refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
-          branch: '{branch}'
+          branch: '$sha1'
           submodule-recursive: '{submodule-recursive}'
           choosing-strategy: default
           jenkins-ssh-credential: '{jenkins-ssh-credential}'
@@ -80,7 +80,7 @@
       - lf-infra-github-scm:
           url: '{git-clone-url}{github-org}/{project}'
           refspec: ''
-          branch: '{branch}'
+          branch: 'refs/heads/{branch}'
           submodule-recursive: '{submodule-recursive}'
           choosing-strategy: default
           jenkins-ssh-credential: '{jenkins-ssh-credential}'

--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -48,7 +48,7 @@
       - lf-infra-github-scm:
           url: '{git-clone-url}{github-org}/{project}'
           refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
-          branch: '{branch}'
+          branches: '$sha1'
           submodule-recursive: '{submodule-recursive}'
           choosing-strategy: default
           jenkins-ssh-credential: '{jenkins-ssh-credential}'
@@ -69,7 +69,7 @@
       - lf-infra-github-scm:
           url: '{git-clone-url}{github-org}/{project}'
           refspec: ''
-          branch: '{branch}'
+          branch: 'refs/heads/{branch}'
           submodule-recursive: '{submodule-recursive}'
           choosing-strategy: default
           jenkins-ssh-credential: '{jenkins-ssh-credential}'


### PR DESCRIPTION
On verify we want it to pick a
pull request branch.  The plugin
knows how to do this if we leave
this param blank.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>