### PR TITLE
Fixed spelling mistake

### DIFF
--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -48,7 +48,7 @@
       - lf-infra-github-scm:
           url: '{git-clone-url}{github-org}/{project}'
           refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
-          branches: '$sha1'
+          branch: '$sha1'
           submodule-recursive: '{submodule-recursive}'
           choosing-strategy: default
           jenkins-ssh-credential: '{jenkins-ssh-credential}'


### PR DESCRIPTION
Should be branch instead of
branches

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>