### PR TITLE
Fix docker tagging DO NOT MERGE

### DIFF
--- a/jjb/device/device-bacnet.yaml
+++ b/jjb/device/device-bacnet.yaml
@@ -9,19 +9,22 @@
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
     archive-artifacts: ''
-    artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
     cron: 'H 11 * * *'
     stream:
       - 'master':
           branch: 'master'
+          docker_tag_version: '0.5.0'
       - 'barcelona':
           branch: 'barcelona'
+          docker_tag_version: '0.2.0'
 
     jobs:
       - '{project-name}-{stream}-verify-java'
       - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
-      - '{project-name}-{stream}-merge-docker'
+      - '{project-name}-{stream}-merge-docker':
+          docker_tag: '{docker_tag_version}-SNAPSHOT'
       - '{project-name}-github-maven-jobs'
-      - '{project-name}-{stream}-release-version-docker-daily-no-sonar'
+      - '{project-name}-{stream}-release-version-docker-daily-no-sonar':
+          docker_tag: '{docker_tag_version}'


### PR DESCRIPTION
Follow the maven convention for docker
tagging based on the stream and corresponding
version in pom.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>