### PR TITLE
Fix docker tagging

### DIFF
--- a/jjb/device/device-bacnet.yaml
+++ b/jjb/device/device-bacnet.yaml
@@ -9,7 +9,6 @@
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
     archive-artifacts: ''
-    artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
     cron: 'H 11 * * *'
     stream:

--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -120,7 +120,6 @@
             DOCKER_ARGS={docker_build_args}
             DOCKER_NAME={docker_name}
             DOCKER_ROOT={docker_root}
-            DOCKER_TAG={docker_tag}
             DOCKERREGISTRY={docker_registry}
       # Do the docker build
       - shell: !include-raw: ../shell/docker-build.sh
@@ -208,8 +207,8 @@
             DOCKER_ARGS={docker_build_args}
             DOCKER_NAME={docker_name}
             DOCKER_ROOT={docker_root}
-            DOCKER_TAG={docker_tag}
             DOCKERREGISTRY={docker_registry}
+
       # Do the docker build
       - shell: !include-raw: ../shell/snapshot-strip.sh
       - shell: !include-raw: ../shell/docker-build.sh

--- a/shell/docker-build.sh
+++ b/shell/docker-build.sh
@@ -3,6 +3,10 @@
 # Do not set -u as DOCKER_ARGS may be unbound
 set -e -o pipefail
 
+if [[ -z "$DOCKER_TAG" ]]; then
+    DOCKER_TAG=$( xmlstarlet sel -N "x=http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:version" pom.xml )
+fi
+
 # Switch to the directory where the Dockerfile is
 cd "$DOCKER_ROOT"
 


### PR DESCRIPTION
Follow the maven convention for docker
tagging based on the stream and corresponding
version in pom.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>