### PR TITLE
Fix reverse trigger for Docker Release

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -223,4 +223,4 @@
     # Doesn't make sense to build unless there are new artifacts released
     triggers:
       - reverse:
-          jobs: '{project-name}-maven-release-master'
+          jobs: '{project-name}-maven-release-{stream}'


### PR DESCRIPTION
The reverse trigger needs the stream
parameterized.  It was hardcoded to master.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>