### PR TITLE
Restore packer-verify job

### DIFF
--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -3,6 +3,7 @@
     build-node: centos7-basebuild-2c-1g
     jobs:
       - '{project-name}-github-ci-jobs'
+      - github-packer-verify
 
     name: ci-management-jobs
     project: ci-management


### PR DESCRIPTION
PR #97 inadvertently removed the packer-verify job which
should have stayed. This patch restores it.

Signed-off-by: Thanh Ha <thanh.ha@linuxfoundation.org>