### PR TITLE
Add jjb-version to the project section

### DIFF
--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -9,3 +9,4 @@
     project: ci-management
     project-name: ci-management
     build-node: centos7-builder-2c-1g
+    jjb-version: 2.0.3

--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -11,6 +11,7 @@
 
     build-node: centos7-builder-2c-1g
     build-timeout: 90
+    jjb-version: 2.0.3
 
     platforms:
       - centos-7
@@ -29,6 +30,7 @@
 
     build-node: centos7-builder-2c-1g
     build-timeout: 90
+    jjb-version: 2.0.3
 
     platforms:
       - centos-7

--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -7,7 +7,6 @@
     # lftools
     lftools-version:  <1.0.0
     packer-version: 1.1.3
-    jjb-version: 2.0.3
 
     # lf-infra-defaults
     jenkins-ssh-credential: 'edgex-jenkins-ssh'


### PR DESCRIPTION
jjb-version can not be defined in
defaults.yaml as it takes a lower
priority there.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>