### PR TITLE
Use image name that is in edgexci cloud

### DIFF
--- a/packer/vars/ubuntu-16.04.json
+++ b/packer/vars/ubuntu-16.04.json
@@ -1,0 +1,6 @@
+{
+  "base_image": "Ubuntu 16.04 (2017-04-24) - LF upload",
+  "distro": "Ubuntu 16.04",
+  "ssh_user": "ubuntu",
+  "cloud_user_data": "provision/null_data.sh"
+}


### PR DESCRIPTION
I tried to modify that name but the
edgexci user did not have permissions
to do so.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>