### PR TITLE
Add relative path to ubuntu-user_data.sh

### DIFF
--- a/packer/vars/ubuntu-16.04.json
+++ b/packer/vars/ubuntu-16.04.json
@@ -2,5 +2,5 @@
   "base_image": "Ubuntu 16.04 (2017-04-24) - LF upload",
   "distro": "Ubuntu 16.04",
   "ssh_user": "ubuntu",
-  "cloud_user_data": "provision/null_data.sh"
+  "cloud_user_data": "../common-packer/provision/ubuntu-user_data.sh"
 }


### PR DESCRIPTION
This file is currently a no-op.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>