### PR TITLE
Add go verify jobs for core-config-seed-go

### DIFF
--- a/jjb/core/core-config-seed-go-yaml
+++ b/jjb/core/core-config-seed-go-yaml
@@ -1,9 +1,9 @@
 ---
 - project:
-    name: edgex-go
-    project-name: edgex-go
-    project: edgex-go
-    mvn-settings: edgex-go-settings
+    name: core-config-seed-go
+    project-name: core-config-seed-go
+    project: core-config-seed-go
+    mvn-settings: core-config-seed-go-settings
     stream:
       - 'master':
           branch: 'master'
@@ -15,5 +15,3 @@
       - '{project-name}-{stream}-verify-go-arm':
           pre_build_script: 'make prepare && make test'
           build_script: 'make build && make docker'
-      - '{project-name}-{stream}-merge-go'
-      - '{project-name}-{stream}-merge-go-arm'

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -113,9 +113,9 @@
           properties-content: |
             PATH=$PATH:/usr/local/go/bin
             GOPATH=$HOME/$BUILD_ID/gopath
-      - shell: !include-raw: ../shell/edgex-go-pre-build.sh
-      # Go build commands
-      - shell: !include-raw: ../shell/edgex-go-build.sh
+      - shell: '{pre_build_script}'
+      - shell: '{build_script}'
+      - shell: '{post_build_script}'
 
 - job-template:
     name: '{project-name}-{stream}-merge-go'
@@ -139,11 +139,8 @@
       - lf-provide-maven-settings:
           global-settings-file: 'global-settings'
           settings-file: '{mvn-settings}'
-      # Set Env
       - shell: '{pre_build_script}'
-      # Go build commands
       - shell: '{build_script}'
-      # Cleanup and push to nexus
       - shell: '{post_build_script}'
 
 - job-template:
@@ -175,8 +172,9 @@
             GOARCH=arm64
             PATH=$PATH:/usr/local/go/bin
             GOPATH=$HOME/$BUILD_ID/gopath/
-      - shell: !include-raw: ../shell/edgex-go-pre-build.sh
-      - shell: !include-raw: ../shell/edgex-go-build.sh
+      - shell: '{pre_build_script}'
+      - shell: '{build_script}'
+      - shell: '{post_build_script}'
 
 - job-template:
     name: '{project-name}-{stream}-merge-go-arm'
@@ -200,9 +198,6 @@
       - lf-provide-maven-settings:
           global-settings-file: 'global-settings'
           settings-file: '{mvn-settings}'
-      # Set Env
       - shell: '{pre_build_script}'
-      # Go build commands
       - shell: '{build_script}'
-      # Cleanup and push to nexus
       - shell: '{post_build_script}'

--- a/shell/edgex-go-build.sh
+++ b/shell/edgex-go-build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-make build
-make docker

--- a/shell/edgex-go-pre-build.sh
+++ b/shell/edgex-go-pre-build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-make prepare
-make test


### PR DESCRIPTION
This required generalizing the existing go templates
so that the verify jobs for the edgex-go monorepo
would continue to work.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>