### PR TITLE
Remove arm64 flag for regular go build

### DIFF
--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -151,8 +151,6 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
-            GOOS=linux
-            GOARCH=arm64
             PATH=$PATH:/usr/local/go/bin
             GOPATH=$HOME/$BUILD_ID/gopath/
             DEPLOY_TYPE=snapshot


### PR DESCRIPTION
Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>