### PR TITLE
Forcibly remove docker images after each build

### DIFF
--- a/jjb/edgex-macros.yaml
+++ b/jjb/edgex-macros.yaml
@@ -7,3 +7,13 @@
           recipients: EdgeX-Jenkins-Alerts@lists.edgexfoundry.org
           notify-every-unstable-build: true
           send-to-individuals: true
+
+- builder:
+    name: edgex-provide-docker-cleanup
+    builders:
+      - shell: |
+          #!/bin/bash
+          set +e  # DO NOT cause build failure if docker rmi fails
+          docker rmi -f $(docker images -a -q)
+          exit 0
+

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -195,6 +195,7 @@
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - shell: '{obj:post_build_script}'
+      - edgex-provide-docker-cleanup
 
 - job-template:
     name: '{project-name}-{stream}-merge-go-arm'
@@ -234,6 +235,7 @@
           server-id: nexus3.edgexfoundry.org
       - shell: '{obj:post_build_script}'
       - lf-provide-maven-settings-cleanup
+      - edgex-provide-docker-cleanup
 
 - job-template:
     name: '{project-name}-{stream}-stage-go-arm'
@@ -276,6 +278,7 @@
           server-id: nexus3.edgexfoundry.org
       - shell: '{obj:post_build_script}'
       - lf-provide-maven-settings-cleanup
+      - edgex-provide-docker-cleanup
 
 - job-template:
     name: '{project-name}-{stream}-stage-go'
@@ -359,6 +362,7 @@
           server-id: nexus3.edgexfoundry.org
       - shell: '{obj:post_build_script}'
       - lf-provide-maven-settings-cleanup
+      - edgex-provide-docker-cleanup
 
 - job-template:
     name: '{project-name}-{stream}-release-go'


### PR DESCRIPTION
This is to accomodate a static build machine.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>