### PR TITLE
Add email publisher for failed blackbox tests

### DIFF
--- a/jjb/blackbox-tests/integration-tests.yaml
+++ b/jjb/blackbox-tests/integration-tests.yaml
@@ -44,9 +44,14 @@
           source bin/env.sh
           bash deploy-edgeX.sh
           cd bin; bash ./run.sh -all postman-integration-test
+
     wrappers:
       - lf-infra-wrappers:
           build-timeout: '{build-timeout}'
           jenkins-ssh-credential: '{jenkins-ssh-credential}'
+
+    publishers:
+      - edgex-jenkins-alerts
+
     triggers:
       - timed: 'H 12 * * *'

--- a/jjb/edgex-macros.yaml
+++ b/jjb/edgex-macros.yaml
@@ -1,17 +1,9 @@
 ---
 
-- property:
-    name: 'edgex-go-x86_64'
-    properties:
-      - inject:
-          properties-content: |
-            GOPATH=$WORKSPACE
-
-- property:
-    name: 'edgex-go-amd64'
-    properties:
-      - inject:
-          properties-content: |
-            GOPATH=$WORKSPACE
-            GOARCH=amd64
-
+- publisher:
+    name: edgex-jenkins-alerts
+    publishers:
+      - email:
+          recipients: EdgeX-Jenkins-Alerts@lists.edgexfoundry.org
+          notify-every-unstable-build: true
+          send-to-individuals: true


### PR DESCRIPTION
Consumers may subcribe to the email list at
https://lists.edgexfoundry.org/mailman/listinfo/edgex-jenkins-alerts