### PR TITLE
Add white-list-target-branches

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -72,6 +72,9 @@
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false
+          white-list-target-branches:
+            - '{branch}'
+
 
 - docker_merge_boiler_plate: &docker_merge_boiler_plate
     name: docker_merge_boiler_plate

--- a/jjb/edgex-templates-docs.yaml
+++ b/jjb/edgex-templates-docs.yaml
@@ -71,6 +71,8 @@
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false
+          white-list-target-branches:
+            - '{branch}'
 
 - docs_merge_boiler_plate: &docs_merge_boiler_plate
     name: docs_merge_boiler_plate

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -70,6 +70,9 @@
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false
+          white-list-target-branches:
+            - '{branch}'
+
 
 - go_merge_boiler_plate: &go_merge_boiler_plate
     name: go_merge_boiler_plate

--- a/jjb/edgex-templates-integration.yaml
+++ b/jjb/edgex-templates-integration.yaml
@@ -64,6 +64,8 @@
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false
+          white-list-target-branches:
+            - '{branch}'
 
 - integration_testing_boiler_plate: &integration_testing_boiler_plate
     name: integration_testing_boiler_plate

--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -61,6 +61,9 @@
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false
+          white-list-target-branches:
+            - '{branch}'
+
 
 - merge_boiler_plate: &merge_boiler_plate
     name: merge_boiler_plate

--- a/jjb/edgex-templates-snap.yaml
+++ b/jjb/edgex-templates-snap.yaml
@@ -71,6 +71,9 @@
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false
+          white-list-target-branches:
+            - '{branch}'
+
 
 - snap_merge_boiler_plate: &snap_merge_boiler_plate
     name: snap_merge_boiler_plate


### PR DESCRIPTION
This will allow specific builds to happen
depending on the target branch of the PR.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>