### PR TITLE
Add option to set DOCKER_TAG

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -23,7 +23,7 @@
     docker_name: 'unnamed'
     # Default to LF standard 'snapshots' docker registry
     docker_registry: '$DOCKER_REGISTRY:10003'
-    docker_tag: 'latest'
+    docker_tag: ''
 
     #####################
     # Job Configuration #
@@ -128,6 +128,7 @@
             DOCKER_NAME={docker_name}
             DOCKER_ROOT={docker_root}
             DOCKERREGISTRY={docker_registry}
+            DOCKER_TAG={docker_tag}
       # Do the docker build
       - shell: !include-raw: ../shell/docker-build.sh
       - inject:
@@ -223,7 +224,7 @@
             DOCKER_NAME={docker_name}
             DOCKER_ROOT={docker_root}
             DOCKERREGISTRY={docker_registry}
-
+            DOCKER_TAG={docker_tag}
       # Do the docker build
       - shell: !include-raw: ../shell/snapshot-strip.sh
       - shell: !include-raw: ../shell/docker-build.sh
@@ -268,6 +269,7 @@
             DOCKER_NAME={docker_name}
             DOCKER_ROOT={docker_root}
             DOCKERREGISTRY={docker_registry}
+            DOCKER_TAG={docker_tag}
       # Do the docker build
       - shell: !include-raw: ../shell/docker-build.sh
       - inject:
@@ -363,7 +365,7 @@
             DOCKER_NAME={docker_name}
             DOCKER_ROOT={docker_root}
             DOCKERREGISTRY={docker_registry}
-
+            DOCKER_TAG={docker_tag}
       # Do the docker build
       - shell: !include-raw: ../shell/snapshot-strip.sh
       - shell: !include-raw: ../shell/docker-build.sh

--- a/jjb/mongo/edgex-mongo.yaml
+++ b/jjb/mongo/edgex-mongo.yaml
@@ -14,10 +14,13 @@
     stream:
       - 'master':
           branch: 'master'
+          docker_tag: 'master'
       - 'barcelona':
           branch: 'barcelona'
+          docker_tag: '0.5.2'
       - 'california':
           branch: 'california'
+          docker_tag: '0.6.0'
     jobs:
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'

--- a/jjb/security/security-secret-store.yaml
+++ b/jjb/security/security-secret-store.yaml
@@ -13,10 +13,10 @@
     stream:
       - 'master':
           branch: 'master'
-      - 'barcelona':
-          branch: 'barcelona'
+          docker_tag: 'master'
       - 'california':
           branch: 'california'
+          docker_tag: '0.6.0'
     jobs:
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
@@ -36,10 +36,10 @@
     stream:
       - 'master':
           branch: 'master'
-      - 'barcelona':
-          branch: 'barcelona'
+          docker_tag: 'master'
       - 'california':
           branch: 'california'
+          docker_tag: '0.6.0'
     jobs:
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'

--- a/jjb/volume/edgex-volume.yaml
+++ b/jjb/volume/edgex-volume.yaml
@@ -14,10 +14,13 @@
     stream:
       - 'master':
           branch: 'master'
+          docker_tag: 'master'
       - 'barcelona':
           branch: 'barcelona'
+          docker_tag: '0.5.2'
       - 'california':
           branch: 'california'
+          docker_tag: '0.6.0'
     jobs:
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'


### PR DESCRIPTION
This is needed so that it can also set DOCKER_TAG
on projects with no pom.xml, which is where the job
normally parses the tag from.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>