### PR TITLE
Add to edgex docker cleanup

### DIFF
--- a/jjb/edgex-macros.yaml
+++ b/jjb/edgex-macros.yaml
@@ -14,7 +14,9 @@
       - shell: |
           #!/bin/bash
           set +e  # DO NOT cause build failure if docker rmi fails
-          docker rmi -f $(docker images -a -q)
+          docker kill $(docker ps -aq)
+          docker rmi -f $(docker images -aq)
+          docker system prune -f -a
           exit 0
 
 - builder:


### PR DESCRIPTION
Added are forcibly kiling running containers and
a forcibly docker system prune -a.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>