### PR TITLE
Increase blackbox tests timeout to 60 minutes

### DIFF
--- a/jjb/blackbox-tests/integration-tests.yaml
+++ b/jjb/blackbox-tests/integration-tests.yaml
@@ -6,7 +6,7 @@
     project: blackbox-testing
     archive-artifacts: ''
     mvn-settings: blackbox-testing-settings
-    build-timeout: 30
+    build-timeout: 60
     stream:
       - 'master':
           branch: 'master'


### PR DESCRIPTION
Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>