### PR TITLE
Refactor java docker builds

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -227,7 +227,9 @@
             DOCKER_TAG={docker_tag}
       # Do the docker build
       - shell: !include-raw: ../shell/snapshot-strip.sh
-      - shell: !include-raw: ../shell/docker-build.sh
+      - shell: !include-raw-escape:
+          - ../shell/get-upstream-autorelease.sh
+          - ../shell/docker-build.sh
       - inject:
           # Import the docker image information from the build step
           properties-file: 'env_inject.txt'
@@ -368,7 +370,9 @@
             DOCKER_TAG={docker_tag}
       # Do the docker build
       - shell: !include-raw: ../shell/snapshot-strip.sh
-      - shell: !include-raw: ../shell/docker-build.sh
+      - shell: !include-raw-escape:
+          - ../shell/get-upstream-autorelease.sh
+          - ../shell/docker-build.sh
       - inject:
           # Import the docker image information from the build step
           properties-file: 'env_inject.txt'

--- a/shell/docker-build.sh
+++ b/shell/docker-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Ensure we fail the job if any steps fail
 # Do not set -u as DOCKER_ARGS may be unbound
-set -e -o pipefail
+set -ex -o pipefail
 
 if [[ -z "$DOCKER_TAG" ]]; then
     DOCKER_TAG=$( xmlstarlet sel -N "x=http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:version" pom.xml )
@@ -13,13 +13,24 @@ cd "$DOCKER_ROOT"
 # Jenkins global env var of the DOCKER_REGISTRY which the docker-login step uses
 IMAGE_NAME="$DOCKERREGISTRY/$DOCKER_NAME:$DOCKER_TAG"
 
+# Determine if there is an autorelease to point to and
 # Build the docker image
 
-# Allow word splitting
-# shellcheck disable=SC2086
-docker build $DOCKER_ARGS . -t $IMAGE_NAME | tee "$WORKSPACE/docker_build_log.txt"
+if [[ -z "$AUTORELEASE" ]]; then
+  echo "There is no autorelease"
+  # Allow word splitting
+  # shellcheck disable=SC2086
+  docker build $DOCKER_ARGS . -t $IMAGE_NAME | tee "$WORKSPACE/docker_build_log.txt"
+
+else
+  # Allow word splitting
+  # shellcheck disable=SC2086
+  docker build --build-arg MVN_COMMAND="mvn dependency:copy -Dstagingpath=autorelease-$AUTORELEASE" $DOCKER_ARGS . -t $IMAGE_NAME | tee "$WORKSPACE/docker_build_log.txt"
+
+fi
+
+
 
 # Write DOCKER_IMAGE information to a file so it can be injected into the
 # environment for following steps
 echo "DOCKER_IMAGE=$IMAGE_NAME" >> "$WORKSPACE/env_inject.txt"
-

--- a/shell/get-upstream-autorelease.sh
+++ b/shell/get-upstream-autorelease.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Do not fail this job as this is a stopgap for now.
+set +e
+
+upstream_name=$(curl $BUILD_URL/consoleText | grep "Started by upstream project" | awk -F '"' '{print $2}')
+upstream_number=$(curl $BUILD_URL/consoleText | grep "Started by upstream project" | awk -F '"' '{print $3}' | awk -F ' ' '{print$3}')
+upstream_url="https://jenkins.edgexfoundry.org/job/$upstream_name/$upstream_number/consoleText"
+
+AUTORELEASE=$(curl $upstream_url | grep "Completed uploading files to autorelease" | awk -F '-' '{print $2}' | awk -F '.' '{print $1}')


### PR DESCRIPTION
This patch fixes the docker jobs which are triggered by
and upstream maven-release.  It queries the upstream job
for the specific nexus autorelease and uses it to override
the mvn command in the docker build to point at that autorelease
repo.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>