### PR TITLE
Add snapcraft clean before build

### DIFF
--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -21,7 +21,7 @@
          build_script: !include-raw-escape: shell/edgex-publish-snap.sh
      - '{project-name}-{stream}-verify-snap-arm':
          build-node: cavium-arm64
-         build_script: 'snapcraft'
+         build_script: 'snapcraft clean && snapcraft'
          status-context: '{project-name}-snap-{stream}-verify-arm'
      - '{project-name}-{stream}-verify-snap':
          status-context: '{project-name}-snap-{stream}-verify'

--- a/shell/edgex-publish-snap.sh
+++ b/shell/edgex-publish-snap.sh
@@ -4,6 +4,7 @@ set -e -o pipefail
 snapcraft login --with $HOME/EdgeX
 
 # Build the snap
+snapcraft clean
 snapcraft
 
 # Push the generated snap and grab the revision number


### PR DESCRIPTION
This should account for issues with static builder.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>