### PR TITLE
Remove old java verify and java merge jobs

### DIFF
--- a/jjb/core/core-command-client.yaml
+++ b/jjb/core/core-command-client.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-command.yaml
+++ b/jjb/core/core-command.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-core-command
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-config-seed.yaml
+++ b/jjb/core/core-config-seed.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-core-config-seed
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-config-watcher.yaml
+++ b/jjb/core/core-config-watcher.yaml
@@ -15,6 +15,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-consul.yaml
+++ b/jjb/core/core-consul.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-core-consul
     docker_root: ''
     docker_build_args: '-f Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -24,6 +25,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f Dockerfile.aarch64'
           docker_name: docker-core-consul-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f Dockerfile.aarch64'

--- a/jjb/core/core-data-client.yaml
+++ b/jjb/core/core-data-client.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-data.yaml
+++ b/jjb/core/core-data.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-core-data
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-domain.yaml
+++ b/jjb/core/core-domain.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-exception.yaml
+++ b/jjb/core/core-exception.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-metadata-client.yaml
+++ b/jjb/core/core-metadata-client.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-metadata.yaml
+++ b/jjb/core/core-metadata.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-core-metadata
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'

--- a/jjb/core/core-test.yaml
+++ b/jjb/core/core-test.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/device/device-bacnet.yaml
+++ b/jjb/device/device-bacnet.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-device-bacnet
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     build-node: centos7-docker-4c-2g
     cron: 'H 11 * * *'
@@ -19,8 +20,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -29,6 +28,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-device-bacnet-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/device/device-bluetooth.yaml
+++ b/jjb/device/device-bluetooth.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-device-bluetooth
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-device-bluetooth-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/device/device-controller.yaml
+++ b/jjb/device/device-controller.yaml
@@ -13,6 +13,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/device/device-domain.yaml
+++ b/jjb/device/device-domain.yaml
@@ -13,6 +13,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/device/device-fischertechnik.yaml
+++ b/jjb/device/device-fischertechnik.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-device-fischertechnik
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,21 +21,7 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
       - '{project-name}-{stream}-release-version-docker-daily-no-sonar'
-      - '{project-name}-{stream}-verify-docker-arm':
-          build-node: cavium-arm64
-          docker_build_args: '-f docker-files/Dockerfile.aarch64'
-          docker_name: docker-device-fischertechnik-arm64
-      - '{project-name}-{stream}-merge-docker-arm':
-          build-node: cavium-arm64
-          docker_build_args: '-f docker-files/Dockerfile.aarch64'
-          docker_name: docker-device-fischertechnik-arm64
-      - '{project-name}-{stream}-release-version-docker-arm-daily-no-sonar':
-          build-node: cavium-arm64
-          docker_build_args: '-f docker-files/Dockerfile.aarch64'
-          docker_name: docker-device-fischertechnik-arm64

--- a/jjb/device/device-modbus.yaml
+++ b/jjb/device/device-modbus.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-device-modbus
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-device-modbus-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/device/device-mqtt.yaml
+++ b/jjb/device/device-mqtt.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-device-mqtt
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-device-mqtt-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/device/device-scheduling.yaml
+++ b/jjb/device/device-scheduling.yaml
@@ -16,5 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/device/device-sdk-tools.yaml
+++ b/jjb/device/device-sdk-tools.yaml
@@ -20,4 +20,3 @@
     jobs:
       - '{project-name}-{stream}-generate-verify-java'
       - '{project-name}-{stream}-generate-merge-java'
-      - '{project-name}-github-maven-jobs'

--- a/jjb/device/device-sdk.yaml
+++ b/jjb/device/device-sdk.yaml
@@ -15,6 +15,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/device/device-snmp.yaml
+++ b/jjb/device/device-snmp.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-device-snmp
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-device-snmp-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/device/device-virtual.yaml
+++ b/jjb/device/device-virtual.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-device-virtual
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-device-virtual-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -24,6 +24,7 @@
     # Default to LF standard 'snapshots' docker registry
     docker_registry: '$DOCKER_REGISTRY:10003'
     docker_tag: ''
+    status-context: ''
 
     #####################
     # Job Configuration #
@@ -68,7 +69,7 @@
       - github-pull-request:
           trigger-phrase: '^recheck$'
           only-trigger-phrase: false
-          status-context: '{project}-{branch}-Docker-Verify'
+          status-context: '{status-context}'
           permit-all: true
           github-hooks: true
           auto-close-on-fail: false
@@ -301,7 +302,8 @@
     <<: *docker_job_boiler_plate
     # yamllint disable-line rule:key-duplicates
     <<: *docker_verify_boiler_plate
-
+    
+    
     builders:
       - lf-infra-docker-login:
           global-settings-file: 'global-settings'

--- a/jjb/export/export-client.yaml
+++ b/jjb/export/export-client.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-export-client
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'

--- a/jjb/export/export-distro.yaml
+++ b/jjb/export/export-distro.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-export-distro
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'

--- a/jjb/export/export-domain.yaml
+++ b/jjb/export/export-domain.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/export/export-test.yaml
+++ b/jjb/export/export-test.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/support/support-domain.yaml
+++ b/jjb/support/support-domain.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/support/support-logging-client.yaml
+++ b/jjb/support/support-logging-client.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/support/support-logging.yaml
+++ b/jjb/support/support-logging.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-support-logging
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'

--- a/jjb/support/support-notifications-client.yaml
+++ b/jjb/support/support-notifications-client.yaml
@@ -16,6 +16,4 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-github-maven-jobs'

--- a/jjb/support/support-notifications.yaml
+++ b/jjb/support/support-notifications.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-support-notifications
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-support-notifications-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/support/support-rulesengine.yaml
+++ b/jjb/support/support-rulesengine.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-support-rulesengine
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-support-rulesengine-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'

--- a/jjb/support/support-scheduler.yaml
+++ b/jjb/support/support-scheduler.yaml
@@ -8,6 +8,7 @@
     docker_name: docker-support-scheduler
     docker_root: ''
     docker_build_args: '-f docker-files/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
     archive-artifacts: ''
     artifact-version: '0.2.0-SNAPSHOT'
     build-node: centos7-docker-4c-2g
@@ -20,8 +21,6 @@
       - 'california':
           branch: 'california'
     jobs:
-      - '{project-name}-{stream}-verify-java'
-      - '{project-name}-{stream}-merge-java'
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
       - '{project-name}-github-maven-jobs'
@@ -30,6 +29,7 @@
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'
           docker_name: docker-support-scheduler-arm64
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
       - '{project-name}-{stream}-merge-docker-arm':
           build-node: cavium-arm64
           docker_build_args: '-f docker-files/Dockerfile.aarch64'


### PR DESCRIPTION
We use global-jjb lf-maven-jobs now.  Also fix status context
for docker verify arm template.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>