### PR TITLE
shell/edgex-publish-snap.sh: remove incorrect --channel option

### DIFF
--- a/shell/edgex-publish-snap.sh
+++ b/shell/edgex-publish-snap.sh
@@ -11,4 +11,4 @@ snapcraft
 REVISION=$(snapcraft push edgexfoundry*.snap | awk '/Revision/ {print $2}')
 
 # Release the snap to channel
-snapcraft release edgexfoundry $REVISION --channel=$SNAP_CHANNEL
+snapcraft release edgexfoundry $REVISION $SNAP_CHANNEL


### PR DESCRIPTION
snapcraft just takes the channel as an argument, not as a --channel option.

Fixes #203 

Should fix builds that succeed in building the snap, but fail to release the snap such as https://jenkins.edgexfoundry.org/view/Snap/job/edgex-go-snap-california-stage-snap/54/consoleFull