### PR TITLE
jjb/edgex-go/edgex-go-snap.yaml: downgrade california to edge for now

### DIFF
--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -10,7 +10,7 @@
           snap-channel: latest/edge
       - 'california':
           branch: 'california'
-          snap-channel: california/beta
+          snap-channel: california/edge
 
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':

--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -10,7 +10,7 @@
           snap-channel: latest/edge
       - 'california':
           branch: 'california'
-          snap-channel: california/candidate
+          snap-channel: california/beta
 
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':


### PR DESCRIPTION
Until we do more testing we want the california automated snap builds to be released to edge.