### PR TITLE
Upgrade global-jjb and change reverse triggers

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -242,7 +242,7 @@
     # Doesn't make sense to build unless there are new artifacts released
     triggers:
       - reverse:
-          jobs: '{project-name}-maven-release-{stream}'
+          jobs: '{project-name}-maven-stage-{stream}'
 
 - job-template:
     name: '{project-name}-{stream}-merge-docker-arm'
@@ -386,4 +386,4 @@
     # Doesn't make sense to build unless there are new artifacts released
     triggers:
       - reverse:
-          jobs: '{project-name}-maven-release-{stream}'
+          jobs: '{project-name}-maven-stage-{stream}'


### PR DESCRIPTION
The reverse triggers now point at maven-stage instead of maven-release

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>