### PR TITLE
Remove core-config-seed-go jobs

### DIFF
--- a/jjb/core/core-config-seed-go.yaml
+++ b/jjb/core/core-config-seed-go.yaml
@@ -8,8 +8,6 @@
     x86_build_script: 'make build && make docker_core_config_seed_go'
     arm_build_script: 'make build && make docker_core_config_seed_go_arm'
     stream:
-      - 'master':
-          branch: 'master'
       - 'california':
           branch: 'california'
     jobs:


### PR DESCRIPTION
This service has been migrated to the edgex-go monorepo.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>