### PR TITLE
Fix security vault docker tag variable

### DIFF
--- a/jjb/security/security-secret-store.yaml
+++ b/jjb/security/security-secret-store.yaml
@@ -16,7 +16,7 @@
           docker_tag: 'master'
       - 'california':
           branch: 'california'
-          docker_tag: '0.6.0'
+          docker_tag: '0.1.1'
     jobs:
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
@@ -39,7 +39,7 @@
           docker_tag: 'master'
       - 'california':
           branch: 'california'
-          docker_tag: '0.6.0'
+          docker_tag: '0.1.1'
     jobs:
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'


### PR DESCRIPTION
This is a bug in CI.  This is a workaround until I get a solid fix in place.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>