### PR TITLE
edgex-go-snap.yaml: specify docker nodes for snap jobs

### DIFF
--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -15,9 +15,11 @@
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':
          build-node: cavium-arm64
-     - '{project-name}-{stream}-stage-snap'
+     - '{project-name}-{stream}-stage-snap':
+         build-node: centos7-docker-4c-2g
      - '{project-name}-{stream}-verify-snap-arm':
          build-node: cavium-arm64
          status-context: '{project-name}-{stream}-verify-arm'
      - '{project-name}-{stream}-verify-snap':
+         build-node: centos7-docker-4c-2g
          status-context: '{project-name}-{stream}-verify'


### PR DESCRIPTION
We actually do need to specify the build nodes for the snap build jobs, as they require docker, and only these hosts have docker available.