### PR TITLE
Add required global vars for sigul

### DIFF
--- a/jenkins-config/global-vars-production.sh
+++ b/jenkins-config/global-vars-production.sh
@@ -7,4 +7,6 @@ JENKINS_HOSTNAME=vex-yul-edgex-jenkins-1
 LOGS_SERVER=https://logs.edgexfoundry.org
 NEXUS_URL=https://nexus.edgexfoundry.org
 REGISTRY_PORTS=10001 10002 10003 10004
+SIGUL_BRIDGE_IP=10.30.120.3
+SIGUL_KEY=edgex-release-2018
 SILO=production

--- a/jenkins-config/global-vars-sandbox.sh
+++ b/jenkins-config/global-vars-sandbox.sh
@@ -6,4 +6,6 @@ JENKINS_HOSTNAME=vex-yul-edgex-jenkins-2
 LOGS_SERVER=https://logs.edgexfoundry.org
 NEXUS_URL=https://nexus.edgexfoundry.org
 REGISTRY_PORTS=10001 10002 10003
+SIGUL_BRIDGE_IP=10.30.120.3
+SIGUL_KEY=edgex-sandbox
 SILO=sandbox


### PR DESCRIPTION
Sigul requires certain environment variables be set in Jenkins.
Configure both the production and sandbox systems with the correct
values.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>