### PR TITLE
Add facility to use a different version of golang

### DIFF
--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -17,6 +17,9 @@
     post_build_script: ''
     status-context: ''
     workspace: '$HOME/$BUILD_ID/gopath/src/github.com/edgexfoundry/{project-name}/'
+    go-root: '/usr/local/go'
+    path: '$PATH:$GOROOT/bin'
+
     #####################
     # Job Configuration #
     #####################
@@ -122,7 +125,8 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
-            PATH=$PATH:/usr/local/go/bin
+            GOROOT='{go-root}'
+            PATH='{path}'
             GOPATH=$HOME/$BUILD_ID/gopath
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -155,9 +159,9 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
-            PATH=$PATH:/usr/local/go/bin
-            GOPATH=$HOME/$BUILD_ID/gopath/
-            DEPLOY_TYPE=snapshot
+            GOROOT='{go-root}'
+            PATH='{path}'
+            GOPATH=$HOME/$BUILD_ID/gopath
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - lf-infra-create-netrc:
@@ -192,10 +196,11 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
+            GOROOT='{go-root}'
+            PATH='{path}'
+            GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
-            PATH=/usr/local/go/bin:$PATH
-            GOPATH=$HOME/$BUILD_ID/gopath/
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - shell: '{obj:post_build_script}'
@@ -228,10 +233,11 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
+            GOROOT='{go-root}'
+            PATH='{path}'
+            GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
-            PATH=/usr/local/go/bin:$PATH
-            GOPATH=$HOME/$BUILD_ID/gopath/
             DEPLOY_TYPE=snapshot
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -271,10 +277,11 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
+            GOROOT='{go-root}'
+            PATH='{path}'
+            GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
-            PATH=/usr/local/go/bin:$PATH
-            GOPATH=$HOME/$BUILD_ID/gopath/
             DEPLOY_TYPE=staging
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -314,9 +321,10 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
+            GOROOT='{go-root}'
+            PATH='{path}'
+            GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
-            PATH=$PATH:/usr/local/go/bin
-            GOPATH=$HOME/$BUILD_ID/gopath/
             DEPLOY_TYPE=staging
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -355,10 +363,11 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
+            GOROOT='{go-root}'
+            PATH='{path}'
+            GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
-            PATH=/usr/local/go/bin:$PATH
-            GOPATH=$HOME/$BUILD_ID/gopath/
             DEPLOY_TYPE=release
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -395,9 +404,10 @@
           settings-file: '{mvn-settings}'
       - inject:
           properties-content: |
+            GOROOT='{go-root}'
+            PATH='{path}'
+            GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
-            PATH=$PATH:/usr/local/go/bin
-            GOPATH=$HOME/$BUILD_ID/gopath/
             DEPLOY_TYPE=release
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'

--- a/jjb/security/security-secret-store.yaml
+++ b/jjb/security/security-secret-store.yaml
@@ -6,6 +6,7 @@
     mvn-settings: security-secret-store-settings
     build-node: centos7-docker-4c-2g
     build_script: 'make build && make dockers'
+    go-root: '/opt/go'
     stream:
       - 'master':
           branch: 'master'
@@ -13,5 +14,11 @@
           branch: 'california'
     jobs:
       - '{project-name}-{stream}-verify-go'
-      - '{project-name}-{stream}-merge-go'
-
+      - '{project-name}-{stream}-merge-go':
+          post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
+      - '{project-name}-{stream}-merge-go-arm':
+          post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
+      - '{project-name}-{stream}-stage-go':
+          post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
+      - '{project-name}-{stream}-stage-go-arm':
+          post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh

--- a/shell/security-secret-store-go-docker-push.sh
+++ b/shell/security-secret-store-go-docker-push.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Ensure we fail the job if any steps fail
+set -e -o pipefail
+
+# Required parameters:
+#
+#  VERSION: Set this value based on the VERSION file in the project root.
+#  DEPLOY_TYPE: Can be `snapshot`, `staging` or`release`
+#    `snapshot` will push docker images to:
+#       1) nexus3.edgexfoundry.org:10003 with a GIT_SHA-VERSION tag
+#    `staging` will push docker images to:
+#       1) nexus3.edgexfoundry.org:10004 with the `latest` tag
+#       2) edgexfoundry dockerhub with the `latest` tag
+#    `release` will push docker images to:
+#       1) nexus3.edgexfoundry.org:10002 with the `latest` tag and `VERSION` tag
+#       2) edgexfoundry dockerhub with the `latest` tag and `VERSION` tag
+#
+if [[ `uname -m` != "x86_64" ]]; then
+  ARCH=-arm64
+else
+  ARCH=''
+fi
+
+GIT_SHA=$(git rev-parse HEAD)
+VERSION=$(cat VERSION)
+## Query build docker images, retag and push to respective repos based on DEPLOY_TYPE
+images=( $(docker images --format "{{.Repository}}:{{.ID}}" --filter "label=git_sha=$GIT_SHA" | grep 'edgexfoundry.*-go' | sort -u))
+for image in "${images[@]}"; do
+  image_id=$(echo $image | awk -F ':' '{print $2}')
+  image_repo=$(echo $image | awk -F ':' '{print $1}')
+  case $DEPLOY_TYPE in
+    'snapshot' )
+      docker tag $image_id "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}"$ARCH:$GIT_SHA-$VERSION
+      docker push "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}"$ARCH:$GIT_SHA-$VERSION
+      ;;
+    'staging' )
+      docker tag $image_id "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10004}"$ARCH:$GIT_SHA-$VERSION
+      docker push "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10004}"$ARCH:$GIT_SHA-$VERSION
+      docker tag $image_id "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10004}"$ARCH:$VERSION
+      docker push "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10004}"$ARCH:$VERSION
+
+      ;;
+    'release' )
+      docker tag $image_id "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10002}"$ARCH:latest
+      docker push "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10002}"$ARCH:latest
+      docker tag $image_id "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10002}"$ARCH:$VERSION
+      docker push "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10002}"$ARCH:$VERSION
+      export DOCKER_CONTENT_TRUST=1
+      docker tag $image_id $image_repo$ARCH:$VERSION
+      docker tag $image_id $image_repo$ARCH:latest
+      docker push $image_repo$ARCH:$VERSION
+      docker push $image_repo$ARCH:latest
+      ;;
+    * )
+      echo "You must set DEPLOY_TYPE to one of (snapshot, staging, release)."
+      exit 1
+  esac
+done
+
+## Copy generated go binaries, copy to folder and tar up before pushing to nexus raw repos
+## Note the the release case is on hold until the sigul work is completed as there is no way
+## currently to do this in an automated fasion.
+mkdir -p security-secret-store-go-$VERSION
+bin_dir=security-secret-store-go-$VERSION/
+
+go_bins=(edgex-vault-worker)
+
+for bin in "${go_bins[@]}"; do
+  cp $bin $bin_dir
+done
+
+set +x
+case $DEPLOY_TYPE in
+  'snapshot')
+    filename=security-secret-store-go$ARCH-$GIT_SHA-$VERSION.tar.gz
+    tar cvzf $filename $bin_dir
+    curl -n --upload-file $filename https://nexus.edgexfoundry.org/content/sites/security-secret-store/snapshots/$filename
+    ;;
+  'staging')
+    filename=security-secret-store-go$ARCH-$VERSION.tar.gz
+    tar cvzf $filename $bin_dir
+    curl -n --upload-file $filename https://nexus.edgexfoundry.org/content/sites/security-secret-store/staging/$filename
+    ;;
+  'release')
+    filename=security-secret-store-go$ARCH-$VERSION.tar.gz
+    tar cvzf $filename $bin_dir
+    #curl -n --upload-file $filename https://nexus.edgexfoundry.org/content/sites/security-secret-store/release/$filename
+    ;;
+  *)
+    echo "You must set DEPLOY_TYPE to one of (snapshot, staging, release)."
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This patch adds GOROOT with a default.  The user can set it to
any arbitray go installation.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>