### PR TITLE
Add temporary workaround to for SSS

### DIFF
--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -12,6 +12,7 @@
 
     branch: master
     submodule-recursive: true
+    golang_arm_script: ''
     pre_build_script: ''
     build_script: ''
     post_build_script: ''
@@ -202,6 +203,7 @@
             GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
+      - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - shell: '{obj:post_build_script}'
@@ -240,6 +242,7 @@
             GOOS=linux
             GOARCH=arm64
             DEPLOY_TYPE=snapshot
+      - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - lf-infra-create-netrc:
@@ -284,6 +287,7 @@
             GOOS=linux
             GOARCH=arm64
             DEPLOY_TYPE=staging
+      - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - lf-infra-create-netrc:
@@ -370,6 +374,7 @@
             GOOS=linux
             GOARCH=arm64
             DEPLOY_TYPE=release
+      - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - lf-infra-create-netrc:

--- a/jjb/security/security-secret-store.yaml
+++ b/jjb/security/security-secret-store.yaml
@@ -17,11 +17,18 @@
 
     jobs:
       - '{project-name}-{stream}-verify-go'
+      - '{project-name}-{stream}-verify-go-arm':
+          golang_arm_script: !include-raw-escape: shell/install_arm_golang.sh
+          go-root: '/opt/go1105/go'
       - '{project-name}-{stream}-merge-go':
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
       - '{project-name}-{stream}-merge-go-arm':
+          go-root: '/opt/go1105/go'
+          golang_arm_script: !include-raw-escape: shell/install_arm_golang.sh
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
       - '{project-name}-{stream}-stage-go':
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
       - '{project-name}-{stream}-stage-go-arm':
+          go-root: '/opt/go1105/go'
+          golang_arm_script: !include-raw-escape: shell/install_arm_golang.sh
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh

--- a/shell/install_arm_golang.sh
+++ b/shell/install_arm_golang.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This is a temporary workaround for security-secret-store, which advertently depended on golang 1.10.X
+# before the project officially moved.  Install dynamically at runtime for now.
+sudo mkdir /opt/go1105
+sudo curl -L https://dl.google.com/go/go1.10.5.linux-arm64.tar.gz -o go1.10.5.linux-arm64.tar.gz
+sudo tar -C /opt/go1105 -xzf go1.10.5.linux-arm64.tar.gz
+GOROOT=/opt/go1105/go
+PATH=$PATH:$GOROOT/bin
+go version


### PR DESCRIPTION
They need golang 1.10.X, which is ahead of the project

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>