### PR TITLE
Initial implementation of a base docker image for docker based Go builds

### DIFF
--- a/docker/golang-base/Dockerfile
+++ b/docker/golang-base/Dockerfile
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2018
+# Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+FROM golang:1.11.2-alpine3.7
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2018: Intel'
+
+RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
+
+RUN apk update && \
+    apk add --no-cache linux-headers make gcc musl-dev git glide
+
+#Optional dependencies. These are useful for generating reports for tools like SonarQube and Jenkins
+
+# Installing gometalinter
+# Usage example: gometalinter.v2 --checkstyle --vendor --disable gotype --deadline=120s --config=/linter-settings.json ./...
+RUN  go get -u gopkg.in/alecthomas/gometalinter.v2 &&  gometalinter.v2 --install
+COPY docker/golang-base/linter-settings.json /
+
+# Installing gocov to output code coverage xml files. Useful for SonarQube code coverage
+# Usage Example: gocov test ./... | gocov-xml
+RUN go get github.com/axw/gocov/... && \
+    go get github.com/AlekSi/gocov-xml
+
+# Install JUnit style plugin for exporting to report.xml files. Useful for Jenkins JUnit Plugin
+# Usage example: go test ./... -v 2>&1 | go-junit-report
+RUN go get -u github.com/jstemmer/go-junit-report
+

--- a/docker/golang-base/linter-settings.json
+++ b/docker/golang-base/linter-settings.json
@@ -1,0 +1,22 @@
+{
+  "Enable": [
+    "gas",
+    "megacheck",
+    "ineffassign",
+    "deadcode",
+    "goconst",
+    "misspell",
+    "unconvert",
+    "vet",
+    "vetshadow",
+    "errcheck",
+    "interfacer",
+    "unparam",
+    "varcheck",
+    "structcheck"
+  ],
+  "Deadline": "120s",
+  "Exclude": [
+    "doc.go"
+  ]
+}


### PR DESCRIPTION
Two files added to ci-mangement repository based on a conversation with @JPWKU.

1. docker/golang-base/Dockerfile - Base docker image definition. Build tools such as gcc, make, etc. included in base image to speed up docker based builds. Also included are optional linting and code coverage tools that we use in our build process to generate reports with SonarQube and Jenkins.

2. docker/golang-base/linter-settings.json - Go Meta Linter default settings. Could be overridden in images that inherit from the base.