### PR TITLE
revert change due to Go version issues

### DIFF
--- a/jjb/device/device-sdk-go.yaml
+++ b/jjb/device/device-sdk-go.yaml
@@ -5,8 +5,8 @@
     project-name: device-sdk-go
     project: device-sdk-go
     mvn-settings: device-sdk-go-settings
-    pre_build_script: 'make test'
-    build_script: 'make build && make docker'
+    pre_build_script: 'make prepare && make test'
+    build_script: 'make build'
     cron: 'H 11 * * *'
     stream:
       - 'master':


### PR DESCRIPTION
Need to revert change due to Go lang version 1.11.2 not being installed

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>