### PR TITLE
Adding a base docker image for builds using gcc

### DIFF
--- a/docker/gcc-base/Dockerfile
+++ b/docker/gcc-base/Dockerfile
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2018
+# Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+FROM alpine:3.7
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2018: Intel'
+
+RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
+
+RUN apk update && \
+    apk add --update --no-cache build-base git gcc cmake make linux-headers yaml yaml-dev libmicrohttpd-dev libcurl curl-dev wget

--- a/jjb/ci-management/docker-gcc.yaml
+++ b/jjb/ci-management/docker-gcc.yaml
@@ -1,0 +1,25 @@
+---
+
+- project:
+    name: docker-gcc-builder-jobs
+    project-name: ci-management-gcc
+    project: ci-management
+    mvn-settings: ci-management-settings
+    docker_name: edgex-gcc-base
+    docker_build_args: '-f docker/gcc-base/Dockerfile'
+    status-context: '{project-name}-{stream}-Docker-Verify'
+    build-node: centos7-docker-4c-2g
+    cron: 'H 11 * * *'
+    stream:
+      - 'master':
+          branch: 'master'
+          docker_tag: 'latest'
+    jobs:
+      - '{project-name}-{stream}-verify-docker'
+      - '{project-name}-{stream}-merge-docker'
+      - '{project-name}-{stream}-verify-docker-arm':
+          build-node: ubuntu18.04-docker-arm64-4c-2g
+          status-context: '{project-name}-{stream}-Docker-Verify-ARM'
+      - '{project-name}-{stream}-merge-docker-arm':
+          build-node: ubuntu18.04-docker-arm64-4c-2g
+          docker_name: edgex-gcc-base-arm64


### PR DESCRIPTION
Similar to the go base image that @ernestojeda made. Goal is to have a bare bones image for the gcc tool chain.

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>