### PR TITLE
Add go-root to set Go 1.11

### DIFF
--- a/jjb/device/device-sdk-go.yaml
+++ b/jjb/device/device-sdk-go.yaml
@@ -16,7 +16,11 @@
 
     jobs:
       - '{project-name}-{stream}-verify-go':
+          pre_build_script: !include-raw-escape: shell/install_device_sdk_go_deps.sh
           status-context: '{project-name}-{stream}-verify'
+          go-root: '/opt/go1.11.2/go'
       - '{project-name}-{stream}-verify-go-arm':
+          pre_build_script: !include-raw-escape: shell/install_device_sdk_go_deps.sh
           status-context: '{project-name}-{stream}-verify-arm'
+          go-root: '/opt/go1.11.2/go'
 

--- a/shell/install_device_sdk_go_deps.sh
+++ b/shell/install_device_sdk_go_deps.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "--> install_device_sdk_go_deps.sh"
+
+GO_VERSION=${GO_VERSION:-1.11.2}
+GOARCH=${GOARCH:-amd64}
+
+# This is a temporary workaround for device-sdk-go, which will depended on golang 1.11.X
+# Install dynamically at runtime for now.
+sudo mkdir /opt/go${GO_VERSION}
+sudo curl -L https://dl.google.com/go/go${GO_VERSION}.linux-${GOARCH}.tar.gz -o go${GO_VERSION}.linux-${GOARCH}.tar.gz
+sudo tar -C /opt/go${GO_VERSION} -xzf go${GO_VERSION}.linux-${GOARCH}.tar.gz
+GOROOT=/opt/go${GO_VERSION}/go
+PATH=$PATH:$GOROOT/bin
+
+go version


### PR DESCRIPTION
Add custom go-root based off new packer builds after merge of https://github.com/edgexfoundry/ci-management/pull/270

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>