### PR TITLE
Using the EdgeX docker template to build device-sdk-c

### DIFF
--- a/jjb/device/device-sdk-c.yaml
+++ b/jjb/device/device-sdk-c.yaml
@@ -1,20 +1,27 @@
 ---
+
 - project:
     name: device-sdk-c
     project-name: device-sdk-c
     project: device-sdk-c
-    build-node: centos7-builder-2c-1g
-    nexus-group-id: device-sdk-c
     mvn-settings: device-sdk-c-settings
-    archive-artifacts: '$WORKSPACE/device-sdk-c/build/release/*.gz'
-    pre_build_script: ''
-    git_url: '$GIT_URL/$PROJECT'
-    build_script: '$WORKSPACE/device-sdk-c/scripts/build.sh'
-    build_dir: '$WORKSPACE/device-sdk-c/scripts/build'
+    docker_name: docker-device-sdk-c
+    docker_root: ''
+    docker_build_args: '-f scripts/Dockerfile.alpine-3.7'
+    archive-artifacts: '**/release/*.tar.gz'
+    post_build_script: !include-raw-escape: shell/device_sdk_c_build.sh
+    build-node: centos7-docker-4c-2g
     cron: 'H 11 * * *'
     stream:
       - 'master':
-          branch: 'master'          
+          branch: 'master'
+          docker_tag: 'master'
     jobs:
-      - 'github-cmake-verify'
-      - 'github-cmake-stage'
+      - '{project-name}-{stream}-verify-docker'
+      - '{project-name}-{stream}-merge-docker'
+      - '{project-name}-{stream}-verify-docker-arm':
+          build-node: ubuntu18.04-docker-arm64-4c-2g
+          docker_name: docker-device-sdk-c-arm64
+      - '{project-name}-{stream}-merge-docker-arm':
+          build-node: ubuntu18.04-docker-arm64-4c-2g
+          docker_name: docker-device-sdk-c-arm64

--- a/shell/device_sdk_c_build.sh
+++ b/shell/device_sdk_c_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ex -o pipefail
+
+echo "--> device_sdk_c_build.sh"
+
+userId=`id -u`
+groupId=`id -g`
+
+mkdir $WORKSPACE/release
+
+DOCKER_BUILD_CONTAINER=${DOCKER_NAME}-builder-${BUILD_ID}
+
+echo "Starting build container and generating tar.gz"
+# --privileged is required because for some reason when docker bind mounts the
+# on the workspace on the Jenkins build server, it is Read-Only
+docker run --rm -e UID=$userId -e GID=$groupId --privileged -v $WORKSPACE/release:/edgex-c-sdk/build/release ${DOCKER_IMAGE}
+
+echo "Contents of release directory:"
+ls -al $WORKSPACE/release


### PR DESCRIPTION
We are using the `jjb/edgex-templates-docker.yaml` template for the device-sdk-c build due to the fact that the developers are using a Docker image to build the C code. When run, the docker image that is generated, actually compiles the code and generates the deliverable, a tar.gz file in a release directory. So a post build action (shell/device_sdk_c_build.sh) is required to run a container and with the Jenkins workspace bind mounted in to be able to copy the tar.gz out of the container. The docker image in this repo is not really needed in the end and can probably be discarded. Other techniques could potentially be used to extract the tar file including modify the Dockerfile in the device-sdk-c repo to use a multi-stage build compile the c code in the first stage, then in the final stage, copy the deliverable to a scratch image.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>