### PR TITLE
Add snap release job

### DIFF
--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -18,6 +18,8 @@
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':
          build-node: ubuntu18.04-docker-arm64-4c-2g
+     - '{project-name}-release-snap':
+         build-node: centos7-docker-4c-2g
      - '{project-name}-{stream}-stage-snap':
          build-node: centos7-docker-4c-2g
      - '{project-name}-{stream}-verify-snap-arm':

--- a/jjb/edgex-templates-snap.yaml
+++ b/jjb/edgex-templates-snap.yaml
@@ -368,3 +368,29 @@
       - lf-provide-maven-settings-cleanup
       - edgex-provide-snap-cleanup
       - edgex-provide-docker-cleanup
+- job-template:
+    name: '{project-name}-release-snap'
+
+    # Job template for Snap release job
+    #
+    # The purpose of this job template is to run snapcraft release
+
+    <<: *snap_job_boiler_plate
+    # yamllint disable-line rule:key-duplicates
+    <<: *snap_merge_boiler_plate
+
+    parameters:
+      - string:
+          name: SNAP_CHANNEL
+          description: 'Snap channel to release to.'
+      - string:
+          name: SNAP_REVISION
+          description: 'Snap revision to release.'
+
+    builders:
+      - lf-jacoco-nojava-workaround
+      - shell: '{obj:pre_build_script}'
+      - shell: '{obj:build_script}'
+      - shell: '{obj:post_build_script}'
+      - edgex-provide-snap-cleanup
+      - edgex-provide-docker-cleanup


### PR DESCRIPTION
This job is meant to be manually run, providing the snap revision and channel to release the snap to. 

See edgex-go issue https://github.com/edgexfoundry/edgex-go/issues/1079 for more details and edgex-go PR https://github.com/edgexfoundry/edgex-go/pull/950 for the corresponding change to the build scripts that will enable this job.