### PR TITLE
include pre_build_script to install Go 1.11.2

### DIFF
--- a/jjb/device/device-sdk-go.yaml
+++ b/jjb/device/device-sdk-go.yaml
@@ -16,11 +16,11 @@
 
     jobs:
       - '{project-name}-{stream}-verify-go':
-          pre_build_script: !include-raw-escape: shell/install_device_sdk_go_deps.sh
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           status-context: '{project-name}-{stream}-verify'
           go-root: '/opt/go1.11.2/go'
       - '{project-name}-{stream}-verify-go-arm':
-          pre_build_script: !include-raw-escape: shell/install_device_sdk_go_deps.sh
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           status-context: '{project-name}-{stream}-verify-arm'
           go-root: '/opt/go1.11.2/go'
 

--- a/jjb/go-modules/go-mod-core-contracts.yaml
+++ b/jjb/go-modules/go-mod-core-contracts.yaml
@@ -13,5 +13,9 @@
     jobs:
     - '{project-name}-{stream}-verify-go':
           status-context: '{project-name}-{stream}-verify'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go1.11.2/go'
     - '{project-name}-{stream}-verify-go-arm':
           status-context: '{project-name}-{stream}-verify-arm'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go1.11.2/go'

--- a/jjb/go-modules/go-mod-messaging.yaml
+++ b/jjb/go-modules/go-mod-messaging.yaml
@@ -13,5 +13,9 @@
     jobs:
     - '{project-name}-{stream}-verify-go':
           status-context: '{project-name}-{stream}-verify'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go1.11.2/go'
     - '{project-name}-{stream}-verify-go-arm':
           status-context: '{project-name}-{stream}-verify-arm'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go1.11.2/go'

--- a/jjb/go-modules/go-mod-registry.yaml
+++ b/jjb/go-modules/go-mod-registry.yaml
@@ -13,5 +13,9 @@
     jobs:
     - '{project-name}-{stream}-verify-go':
           status-context: '{project-name}-{stream}-verify'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go1.11.2/go'
     - '{project-name}-{stream}-verify-go-arm':
           status-context: '{project-name}-{stream}-verify-arm'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go1.11.2/go'

--- a/shell/install_custom_golang.sh
+++ b/shell/install_custom_golang.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "--> install_device_sdk_go_deps.sh"
+echo "--> install_custom_golang.sh"
 
 GO_VERSION=${GO_VERSION:-1.11.2}
 GOARCH=${GOARCH:-amd64}


### PR DESCRIPTION
- [x] Renamed the Go 1.11 install script for more general use. Technically, it could be used install any Go version. There was a dependency on that script in device-sdk-go, so I had to update that job as well.
- [x] Add pre_build_script to jobs
- [x] Add go-root to jobs

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>