### PR TITLE
Add daily release docker jobs for mongo

### DIFF
--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -240,11 +240,12 @@
       - shell: !include-raw: ../shell/docker-push.sh
 
     triggers:
-      # no reason to add lf-infra-github-pr-trigger here since it doesn't
-      # currently work for merge / push
+      # daily job except for support-rulesengine
       - github
       - pollscm:
-          cron: ''
+          cron: '0 18 * * *'
+      - reverse:
+          jobs: '{project-name}-maven-stage-{stream}'
 
 - job-template:
     name: '{project-name}-{stream}-merge-docker-arm'
@@ -388,8 +389,9 @@
       - shell: !include-raw: ../shell/docker-push.sh
 
     triggers:
-      # no reason to add lf-infra-github-pr-trigger here since it doesn't
-      # currently work for merge / push
+      # daily job except for support-rulesengine
       - github
       - pollscm:
-          cron: ''
+          cron: '0 18 * * *'
+      - reverse:
+          jobs: '{project-name}-maven-stage-{stream}'

--- a/jjb/mongo/edgex-mongo.yaml
+++ b/jjb/mongo/edgex-mongo.yaml
@@ -14,7 +14,6 @@
     stream:
       - 'master':
           branch: 'master'
-          docker_tag: 'master'
           docker_tag: '0.7.0'
       - 'california':
           branch: 'california'
@@ -25,6 +24,7 @@
     jobs:
       - '{project-name}-{stream}-verify-docker'
       - '{project-name}-{stream}-merge-docker'
+      - '{project-name}-{stream}-release-version-docker-daily-no-sonar'
       - '{project-name}-{stream}-verify-docker-arm':
           build-node: ubuntu18.04-docker-arm64-4c-2g
           docker_build_args: '-f Dockerfile.aarch64'
@@ -33,3 +33,8 @@
           build-node: ubuntu18.04-docker-arm64-4c-2g
           docker_build_args: '-f Dockerfile.aarch64'
           docker_name: docker-edgex-mongo-arm64
+      - '{project-name}-{stream}-release-version-docker-arm-daily-no-sonar':
+          build-node: ubuntu18.04-docker-arm64-4c-2g
+          docker_build_args: '-f Dockerfile.aarch64'
+          docker_name: docker-edgex-mongo-arm64
+


### PR DESCRIPTION
Also modify docker template to allow for rulesengine docker job
to still work until we rewrite in golang.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>