### PR TITLE
Remove docker_tag variable from mongo and volume

### DIFF
--- a/jjb/mongo/edgex-mongo.yaml
+++ b/jjb/mongo/edgex-mongo.yaml
@@ -14,7 +14,6 @@
     stream:
       - 'master':
           branch: 'master'
-          docker_tag: '0.7.0'
       - 'california':
           branch: 'california'
           docker_tag: '0.6.0'

--- a/jjb/volume/edgex-volume.yaml
+++ b/jjb/volume/edgex-volume.yaml
@@ -14,8 +14,6 @@
     stream:
       - 'master':
           branch: 'master'
-          docker_tag: 'master'
-          docker_tag: '0.7.0'
       - 'california':
           branch: 'california'
           docker_tag: '0.6.0'


### PR DESCRIPTION
Only removed on master branch, this will allow the tag to be specified
in the VERSION file.

Signed-off-by: Jeremy Phelps <iot.engineering@dell.com>