### PR TITLE
Update Existing Go Templates to use Go 1.11.5

### DIFF
--- a/jjb/device/device-modbus-go.yaml
+++ b/jjb/device/device-modbus-go.yaml
@@ -12,7 +12,7 @@
           branch: 'master'
           pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           build_script: 'make test && make build docker'
-          go-root: '/opt/go1.11.2/go'
+          go-root: '/opt/go-custom/go'
       - 'delhi':
           branch: 'delhi'
 

--- a/jjb/device/device-sdk-go.yaml
+++ b/jjb/device/device-sdk-go.yaml
@@ -5,22 +5,21 @@
     project-name: device-sdk-go
     project: device-sdk-go
     mvn-settings: device-sdk-go-settings
-    pre_build_script: 'make test'
+    pre_build_script: 'make prepare && make test'
     build_script: 'make build && make docker'
     cron: 'H 11 * * *'
     stream:
       - 'master':
           branch: 'master'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          build_script: 'make test && make build docker'
+          go-root: '/opt/go-custom/go'
       - 'delhi':
           branch: 'delhi'
 
     jobs:
       - '{project-name}-{stream}-verify-go':
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           status-context: '{project-name}-{stream}-verify'
-          go-root: '/opt/go1.11.2/go'
       - '{project-name}-{stream}-verify-go-arm':
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           status-context: '{project-name}-{stream}-verify-arm'
-          go-root: '/opt/go1.11.2/go'
 

--- a/jjb/edgex-go/edgex-go.yaml
+++ b/jjb/edgex-go/edgex-go.yaml
@@ -11,7 +11,7 @@
           branch: 'master'
           pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           build_script: 'make test && make build docker'
-          go-root: '/opt/go1.11.2/go'
+          go-root: '/opt/go-custom/go'
       - 'california':
           branch: 'california'
       - 'delhi':

--- a/jjb/go-modules/go-mod-core-contracts.yaml
+++ b/jjb/go-modules/go-mod-core-contracts.yaml
@@ -9,13 +9,11 @@
     stream:
       - 'master':
           branch: 'master'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go-custom/go'
 
     jobs:
     - '{project-name}-{stream}-verify-go':
           status-context: '{project-name}-{stream}-verify'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          go-root: '/opt/go1.11.2/go'
     - '{project-name}-{stream}-verify-go-arm':
           status-context: '{project-name}-{stream}-verify-arm'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          go-root: '/opt/go1.11.2/go'

--- a/jjb/go-modules/go-mod-messaging.yaml
+++ b/jjb/go-modules/go-mod-messaging.yaml
@@ -9,13 +9,11 @@
     stream:
       - 'master':
           branch: 'master'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go-custom/go'
 
     jobs:
     - '{project-name}-{stream}-verify-go':
           status-context: '{project-name}-{stream}-verify'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          go-root: '/opt/go1.11.2/go'
     - '{project-name}-{stream}-verify-go-arm':
           status-context: '{project-name}-{stream}-verify-arm'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          go-root: '/opt/go1.11.2/go'

--- a/jjb/go-modules/go-mod-registry.yaml
+++ b/jjb/go-modules/go-mod-registry.yaml
@@ -9,13 +9,11 @@
     stream:
       - 'master':
           branch: 'master'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          go-root: '/opt/go-custom/go'
 
     jobs:
     - '{project-name}-{stream}-verify-go':
           status-context: '{project-name}-{stream}-verify'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          go-root: '/opt/go1.11.2/go'
     - '{project-name}-{stream}-verify-go-arm':
           status-context: '{project-name}-{stream}-verify-arm'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          go-root: '/opt/go1.11.2/go'

--- a/shell/install_custom_golang.sh
+++ b/shell/install_custom_golang.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 echo "--> install_custom_golang.sh"
 
-GO_VERSION=${GO_VERSION:-1.11.2}
+GO_VERSION=${GO_VERSION:-1.11.5}
 GOARCH=${GOARCH:-amd64}
 
-# This is a temporary workaround for device-sdk-go, which will depended on golang 1.11.X
+# This is a temporary workaround for Go based services, which will depended on golang 1.11.X
 # Install dynamically at runtime for now.
-sudo mkdir /opt/go${GO_VERSION}
+sudo mkdir /opt/go-custom
 sudo curl -L https://dl.google.com/go/go${GO_VERSION}.linux-${GOARCH}.tar.gz -o go${GO_VERSION}.linux-${GOARCH}.tar.gz
-sudo tar -C /opt/go${GO_VERSION} -xzf go${GO_VERSION}.linux-${GOARCH}.tar.gz
-GOROOT=/opt/go${GO_VERSION}/go
+sudo tar -C /opt/go-custom -xzf go${GO_VERSION}.linux-${GOARCH}.tar.gz
+GOROOT=/opt/go-custom/go
 PATH=$PATH:$GOROOT/bin
 
 go version


### PR DESCRIPTION
Changes made:
  - updated `shell/install_custom_golang.sh` to install Go version 1.11.5
  - change `GOROOT` to be `/opt/go-custom/go` to remove any version numbers in the path. This way future updates should not affect the jjb templates only the install script.
  - updated templates referencing the `shell/install_custom_golang.sh` to install only on the master stream

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>