### PR TITLE
Update global-jjb to v0.34.0, use infra-pre-build

### DIFF
--- a/jjb/edgex-templates-docs.yaml
+++ b/jjb/edgex-templates-docs.yaml
@@ -172,6 +172,7 @@
       - timed: '@daily'
 
     builders:
+      - lf-infra-pre-build
       - lf-jacoco-nojava-workaround
       - lf-provide-maven-settings:
           global-settings-file: 'global-settings'

--- a/shell/edgex-publish-docs.sh
+++ b/shell/edgex-publish-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 # Ensure we fail the job if any steps fail
 set -ex -o pipefail
 echo "---> edgex-publish-docs.sh"
@@ -12,9 +12,6 @@ echo "---> edgex-publish-docs.sh"
 #                     release/branch
 #   <NEXUS_REPO>:     Name of the nexus repo to use
 #   <DOC_DIRECTORY>:  Absolute path of doc build step output directory.
-
-PATH=$PATH:~/.local/bin
-pip install --user lftools
 
 zip -r docs.zip ${DOC_DIRECTORY}
 lftools deploy nexus-zip ${NEXUS_URL} ${NEXUS_REPO} ${NEXUS_PATH} docs.zip


### PR DESCRIPTION
Using lf-infra-pre-build will install lftools, rather than installing
it manually in edgex-publish-docs.sh. Path is fixed by using "bash
-l".

Signed-off-by: Eric Ball <eball@linuxfoundation.org>