### PR TITLE
Add lf-infra-pre-build to merge-docs template

### DIFF
--- a/jjb/edgex-templates-docs.yaml
+++ b/jjb/edgex-templates-docs.yaml
@@ -140,6 +140,7 @@
     build-node: centos7-docker-4c-2g
 
     builders:
+      - lf-infra-pre-build
       - lf-jacoco-nojava-workaround
       - lf-provide-maven-settings:
           global-settings-file: 'global-settings'


### PR DESCRIPTION
This will install lftools, which is necessary for the job to
complete.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>