### PR TITLE
fix git-semver-merge-pipeline to specify a branch

### DIFF
--- a/jjb/git-semver/git-semver.yaml
+++ b/jjb/git-semver/git-semver.yaml
@@ -6,5 +6,6 @@
     mvn-settings: git-semver-settings
     jenkins_file: 'Jenkinsfile'
     stream: {}
+    branch: master
     jobs:
       - '{project-name}-merge-pipeline'


### PR DESCRIPTION
missed a line in the job config.

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>