### PR TITLE
Add GH Org to GHPRB whitelist for pipelines.

### DIFF
--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -68,8 +68,10 @@
           trigger-phrase: '^recheck$'
           only-trigger-phrase: false
           status-context: '{status-context}'
-          permit-all: true
+          permit-all: false
           github-hooks: true
+          org-list:
+            - '{github-org}'
           auto-close-on-fail: false
           white-list-target-branches:
             - '{branch}'

--- a/jjb/git-semver/git-semver.yaml
+++ b/jjb/git-semver/git-semver.yaml
@@ -9,3 +9,4 @@
     branch: master
     jobs:
       - '{project-name}-merge-pipeline'
+      - '{project-name}-verify-pipeline'


### PR DESCRIPTION
This address #343 by adding the `{github-org}` from global-jjb to the whitelist for pipeline jobs as well as disabling "Build every pull request automatically without asking" aka `permit-all`.

Additionally, add back the verify job for `git-semver`.

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>