### PR TITLE
pipeline: revert permit-all to true

### DIFF
--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -68,7 +68,7 @@
           trigger-phrase: '^recheck$'
           only-trigger-phrase: false
           status-context: '{status-context}'
-          permit-all: false
+          permit-all: true
           github-hooks: true
           org-list:
             - '{github-org}'


### PR DESCRIPTION
this should sidestep build errors that look like:

```
ERROR: No flow definition, cannot run
```

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>