### PR TITLE
add ci-build-images jjb template and add stream job templates back in…

### DIFF
--- a/jjb/build-images/build-images.yml
+++ b/jjb/build-images/build-images.yml
@@ -1,0 +1,18 @@
+---
+- project:
+    name: ci-build-images
+    project-name: ci-build-images
+    project: ci-build-images
+    mvn-settings: ci-build-images-settings
+    branch: master
+    stream:
+      - 'golang':
+          jenkins_file: golang/Jenkinsfile
+      - 'gcc':
+          jenkins_file: gcc/Jenkinsfile
+      - 'kong':
+          jenkins_file: kong/Jenkinsfile
+
+    jobs:
+      - '{project-name}-{stream}-verify-pipeline'
+      - '{project-name}-{stream}-merge-pipeline'

--- a/jjb/common-views.yaml
+++ b/jjb/common-views.yaml
@@ -37,3 +37,12 @@
     filter-queue: false
     recurse: false
     regex: '.*docs.*'
+
+- view:
+    name: Ci-Build-Images
+    description: 'List of Jenkins build image jobs'
+    view-type: list
+    filter-executors: false
+    filter-queue: false
+    recurse: false
+    regex: '.*-ci-build-images-.*'

--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -113,6 +113,17 @@
     build-node: centos7-docker-4c-2g
 
 - job-template:
+    name: '{project-name}-{stream}-verify-pipeline'
+
+    # Job template for pipeline verify jobs 
+
+    <<: *pipeline_job_boiler_plate
+    # yamllint disable-line rule:key-duplicates
+    <<: *pipeline_verify_boiler_plate
+
+    build-node: centos7-docker-4c-2g
+
+- job-template:
     name: '{project-name}-merge-pipeline'
 
     # Job template for pipeline merge jobs
@@ -124,18 +135,7 @@
     build-node: centos7-docker-4c-2g
 
 - job-template:
-    name: '{project-name}-verify-pipeline-arm'
-
-    # Job template for pipeline verify jobs
-
-    <<: *pipeline_job_boiler_plate
-    # yamllint disable-line rule:key-duplicates
-    <<: *pipeline_verify_boiler_plate
-
-    build-node: ubuntu18.04-docker-arm64-4c-2g
-
-- job-template:
-    name: '{project-name}-merge-pipeline-arm'
+    name: '{project-name}-{stream}-merge-pipeline'
 
     # Job template for pipeline merge jobs
 
@@ -143,4 +143,4 @@
     # yamllint disable-line rule:key-duplicates
     <<: *pipeline_merge_boiler_plate
 
-    build-node: ubuntu18.04-docker-arm64-4c-2g
+    build-node: centos7-docker-4c-2g


### PR DESCRIPTION
Update `jjb/edgex-templates-pipeline.yaml` to add stream templates back in and remove ARM jobs as they are now part of the Pipeline script.

Add `jjb/build-images/ci-build-images.yml` to setup job templates for golang, gcc, and kong base images

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>