### PR TITLE
allow for custom status-context to be passed

### DIFF
--- a/jjb/build-images/build-images.yml
+++ b/jjb/build-images/build-images.yml
@@ -5,6 +5,7 @@
     project: ci-build-images
     mvn-settings: ci-build-images-settings
     branch: master
+    status-context: '{project-name}-{stream}-verify-pipeline'
     stream:
       - 'golang':
           jenkins_file: golang/Jenkinsfile

--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -64,7 +64,7 @@
       - github-pull-request:
           trigger-phrase: '^recheck$'
           only-trigger-phrase: false
-          status-context: '{project-name}-verify-pipeline'
+          status-context: '{status-context}'
           permit-all: false
           github-hooks: true
           org-list:

--- a/jjb/git-semver/git-semver.yaml
+++ b/jjb/git-semver/git-semver.yaml
@@ -7,6 +7,7 @@
     jenkins_file: 'Jenkinsfile'
     stream: {}
     branch: master
+    status-context: '{project-name}-verify-pipeline'
     jobs:
       - '{project-name}-merge-pipeline'
       - '{project-name}-verify-pipeline'


### PR DESCRIPTION
I am reverting the status-context change to allow custom status-context to be passed in at the project level. The `ci-build-images` project has 3/4 different "streams" which break when the status-context is set to `{project-name}-verify-pipeline` at the template level.

This also keeps it consistent with the other JJB templates.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>