### PR TITLE
git-semver: remove local-branch from merge job

### DIFF
--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -30,6 +30,7 @@
           properties-content: |
             BUILD_NODE='{build-node}'
             MVN_SETTINGS={mvn-settings}
+            GIT_BRANCH={branch}
 
     parameters:
       - string:
@@ -84,7 +85,6 @@
             url: '{git-clone-url}{github-org}/{project}'
             refspec: ''
             branch: 'refs/heads/{branch}'
-            local-branch: '{branch}'
             submodule-recursive: '{submodule-recursive}'
             choosing-strategy: default
             jenkins-ssh-credential: '{jenkins-ssh-credential}'


### PR DESCRIPTION
it wasn't working as expected, aka at all, and so setting an environment variable for git-semver to use as an override

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>