### PR TITLE
favor SEMVER_BRANCH envvar over GIT_BRANCH

### DIFF
--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -30,7 +30,7 @@
           properties-content: |
             BUILD_NODE='{build-node}'
             MVN_SETTINGS={mvn-settings}
-            GIT_BRANCH={branch}
+            SEMVER_BRANCH={branch}
 
     parameters:
       - string:


### PR DESCRIPTION
because GIT_BRANCH is set by jenkins and SEMVER_BRANCH has higher
precedence

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>