### PR TITLE
Integrate snap build script into jenkins job definition

### DIFF
--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -21,7 +21,7 @@
          build-node: centos7-docker-4c-2g
      - '{project-name}-{stream}-verify-snap-arm':
          build-node: ubuntu18.04-docker-arm64-4c-2g
-         status-context: '{project-name}-snap-{stream}-verify-arm'
+         status-context: '{project-name}-{stream}-verify-arm'
      - '{project-name}-{stream}-verify-snap':
          build-node: centos7-docker-4c-2g
          status-context: '{project-name}-{stream}-verify'

--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -10,6 +10,7 @@
           snap-channel: latest/edge
       - 'delhi':
           branch: 'delhi'
+          build_script: 'cd snap && ./build.sh'
           snap-channel: delhi/edge
 
     jobs:

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -106,7 +106,7 @@
 
     # Job template for Golang verify jobs
     #
-    # The purpose of this job templte is to run "go build" for
+    # The purpose of this job template is to run "go build" for
     # projects using this template.
     #
     # Required Variables:
@@ -178,7 +178,7 @@
 
     # Job template for Golang verify jobs
     #
-    # The purpose of this job templte is to run "go build" for
+    # The purpose of this job template is to run "go build" for
     # projects using this template.
     #
     # Required Variables:

--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -93,7 +93,7 @@
 
     # Job template for Java verify jobs
     #
-    # The purpose of this job templte is to run "maven clean install" for
+    # The purpose of this job template is to run "maven clean install" for
     # projects using this template.
     #
     # Required Variables:
@@ -165,7 +165,7 @@
 
     # Job template for Java verify jobs for Code Generation (Device SDK Tools)
     #
-    # The purpose of this job templte is to run "maven clean install" for
+    # The purpose of this job template is to run "maven clean install" for
     # projects using this template.
     #
     # Required Variables:

--- a/jjb/edgex-templates-snap.yaml
+++ b/jjb/edgex-templates-snap.yaml
@@ -13,7 +13,7 @@
     branch: master
     submodule-recursive: true
     pre_build_script: ''
-    build_script: 'cd snap/ && ./build.sh'
+    build_script: !include-raw-escape: shell/edgexfoundry-snapcraft.sh
     post_build_script: ''
     status-context: ''
     snap-channel: ''

--- a/jjb/edgex-templates-snap.yaml
+++ b/jjb/edgex-templates-snap.yaml
@@ -86,7 +86,7 @@
 
     # Job template for Snap verify jobs
     #
-    # The purpose of this job templte is to run snap build for
+    # The purpose of this job template is to run snap build for
     # projects using this template.
     #
     # Required Variables:
@@ -163,7 +163,7 @@
 
     # Job template for Snap verify jobs
     #
-    # The purpose of this job templte is to run snap build for
+    # The purpose of this job template is to run snap build for
     # projects using this template.
     #
     # Required Variables:

--- a/shell/edgexfoundry-snapcraft.sh
+++ b/shell/edgexfoundry-snapcraft.sh
@@ -1,16 +1,16 @@
 #!/bin/bash -x
 
-# note that since this script gets included into a yaml string using jjb's
+# Note that since this script gets included into a yaml string using jjb's
 # include-raw-escape macro, we can't use any squiggly braces here, otherwise
-# they will get duplicated
-# for some reason we also can't use include-raw macro because that macro will
-# attempt to interpret anything contianed in a macro as a jenkins key to
-# expand which we also don't want
+# they will get duplicated in the resultant job definition.
+# For some reason we also can't use include-raw macro because that macro will
+# attempt to interpret anything contained in a macro as a jenkins key to
+# expand which we also don't want.
 
-# if we are running inside a jenkins instance then copy the login file 
-# and check if this is a release job
+# If we are running inside a jenkins instance then copy the login file and 
+# figure out what kind of job type we are running as
 if [ -n "$JENKINS_URL" ]; then
-    # since we are running from jenkins, use the workspace as the git root
+    # Since we are running from jenkins, use the workspace as the git root
     GIT_ROOT=$WORKSPACE
     if [ -f "$HOME/EdgeX" ]; then
        cp "$HOME/EdgeX" "$GIT_ROOT/edgex-snap-store-login"
@@ -18,7 +18,7 @@ if [ -n "$JENKINS_URL" ]; then
         echo "I seem to be running on Jenkins, but there's not a snap store login file..." 
     fi
 
-    # figure out what kind of job this is using $JOB_NAME and simplify that 
+    # Figure out what kind of job this is using $JOB_NAME and simplify that 
     # into $JOB_TYPE
     if [[ "$JOB_NAME" =~ .*-snap-.*-stage-snap.* ]]; then
         JOB_TYPE="stage"
@@ -28,72 +28,73 @@ if [ -n "$JENKINS_URL" ]; then
         JOB_TYPE="build"
     fi
 else
-    # not running in a jenkins container, assume the current working directory
-    # is the repo git dir that we want
+    # We're not running in a jenkins container so assume the current working 
+    # directory is the repo git dir that we want
+    # TODO: maybe support providing the dir to use as the git root as an arg
+    # or option to this script?
     GIT_ROOT=$PWD
 fi
 
-# find the name of this snap from the snapcraft.yaml "name" key
-# note that we assume that snapcraf.yaml is located in snap/snapcraft.yaml 
+# Find the name of this snap from the snapcraft.yaml "name" key.
+# Note that we assume that snapcraft.yaml is located in snap/snapcraft.yaml 
 # but it is technically allowed to store it in other locations, we just don't
 # support that here
 # TODO: implement better handling of snapcraft.yaml file discovery
 SNAP_NAME=$(grep -Po '^name: \K(.*)' snap/snapcraft.yaml)
 
-# save the entrypoint.sh script inside the build context we will send to docker
-# we have to do this because the dockerfile needs access to that file from it's
+# Save the entrypoint.sh script inside the build context we will send to docker.
+# We have to do this because the dockerfile needs access to that file from its
 # build context, so either we download the entrypoint script, or we include it
-# into the filesystem build context. downloading isn't great because then 
+# into the filesystem build context. Downloading isn't great because then 
 # there's additional linkages between this script and wherever we download from
-# and it gets complicated to manage that
-# we save it at snap/entrypoint.sh
+# and it gets complicated to manage that.
+# Note the file is saved at snap/entrypoint.sh
 (
 cat <<'EOF'
 #!/bin/bash -e
 
-# Required by click.
+# Required by the python click framework.
 export LC_ALL=C.UTF-8
 export SNAPCRAFT_SETUP_CORE=1
 
-# this tells snapcraft to include a manifest file in the snap
-# detailing which packages were used to build the snap
+# This tells snapcraft to include a manifest file in the snap
+# detailing which packages were used to build the snap.
 export SNAPCRAFT_BUILD_INFO=1
 
-# if snapcraft ever encounters any bugs, we should force it to 
+# If snapcraft ever encounters any bugs, we should force it to 
 # auto-report silently rather than attempt to ask for permission
-# to send a report
+# to send a report.
 export SNAPCRAFT_ENABLE_SILENT_REPORT=1
 
 case "$JOB_TYPE" in 
     "stage")
-        # stage jobs build the snap locally and release it
+        # Stage jobs build the snap locally and release it
         pushd /build > /dev/null
         snapcraft clean
         snapcraft
         popd > /dev/null
         pushd /build > /dev/null
         snapcraft login --with /build/edgex-snap-store-login
-        # push the snap up to the store and get the revision of the snap
+        # Push the snap up to the store and get the revision of the snap
         REVISION=$(snapcraft push "$SNAP_NAME"*.snap | grep -Po 'Revision \K[0-9]+')
-        # now release it on the provided revision and snap channel
+        # Now release it on the provided revision and snap channel
         snapcraft release "$SNAP_NAME" "$REVISION" "$SNAP_CHANNEL" 
-        # also update the meta-data automatically
+        # Also force an update of the meta-data
         snapcraft push-metadata "$SNAP_NAME"*.snap --force
         popd > /dev/null
     ;;
     "release")
-        # release jobs will promote an already built snap revision
-        # in the store to a channel
+        # Release jobs will promote an already built snap revision
+        # in the store to a channel.
         snapcraft login --with /build/edgex-snap-store-login
         snapcraft release "$SNAP_NAME" "$SNAP_REVISION" "$SNAP_CHANNEL"
     ;;
     *)
-        # do normal build and nothing else
+        # Do normal build and nothing else to verify the snap builds
         pushd /build > /dev/null
         snapcraft clean
         snapcraft
         popd > /dev/null
-
     ;;
 esac
 
@@ -102,8 +103,8 @@ EOF
 
 chmod +x "$GIT_ROOT/snap/entrypoint.sh"
 
-# build the container image - providing the relevant architecture we're on
-# to determine which snap arch to download in the docker container
+# Build the container image, providing the relevant architecture we're on
+# to determine which snap arch to download in the docker container.
 case $(arch) in 
     x86_64)
         arch="amd64";;
@@ -115,19 +116,22 @@ esac
 docker build -t edgex-snap-builder:latest --build-arg ARCH="$arch" "$GIT_ROOT" -f- <<'EOF'
 FROM ubuntu:18.04
 
-# allow specifying the architecture from the build arg command line
+# Allow specifying the architecture from the build arg command line
 ARG ARCH
 
-# this is essentially the same as the upstream dockerfile
+# The following snippet is essentially the same as the upstream dockerfile
 # here: https://github.com/snapcore/snapcraft/blob/master/docker/stable.Dockerfile
 # except we also specify the architecture to download so that this works
-# on other architectures
-# basically, we send a command to the snap store for the info on the core +
-# snapcraft snaps, extract the download link from the result and 
-# download and extract the snaps into the docker container
-# we do this because we can't easily run snapd (and thus snaps) inside a docker
-# container without disabling important security protections enabled for 
-# docker containers
+# on other architectures like arm64, etc.
+# Basically, we send a command to the snap store for the info on the core +
+# snapcraft snaps, extract the download link from the JSON result and then 
+# download and extract the snaps into the docker container.
+# We do this because we can't easily run snapd (and thus snaps) inside a 
+# docker container without disabling important security protections enabled 
+# for docker containers.
+# TODO: add a little bit of error checking for the curl calls in case we ever
+# are on a proxy or something and we end up downloading a login page or
+# or something like that
 RUN apt-get update && \
     apt-get dist-upgrade --yes && \
     apt-get install --yes \
@@ -140,30 +144,35 @@ RUN apt-get update && \
     apt-get autoclean --yes && \
     apt-get clean --yes
 
-# the upstream dockerfile just uses this file locally from the repo, but 
-# rather than copy that file into this repo, we can just download it here
-# while unlikely it is possible that the file location could move in the git repo
-# on master branch, so for stability in our builds, we just hard-code the git 
-# commit that most recently updated this file as the revision to download from
-# if this ever breaks, just change this file to copy what the upstream master dockerfile does
+# The upstream dockerfile just uses this file locally from the repo since it's
+# in the same build context, but rather than copy that file here into the 
+# build context before running, we can just download it from github directly
+# While unlikely, it is possible that the file location could move in the 
+# upstream git repo on the master branch, so for stability in our builds, just
+# hard-code the git commit that most recently updated this file as the 
+# revision to download from.
+# Note: If this script ever breaks with the version of snapcraft we downloaded
+# above, try updating this Dockerfile to do same as whatever the upstream
+# docker image does
 ADD https://raw.githubusercontent.com/snapcore/snapcraft/25043ab3667d24688b3d93dcac9f9a74f35dae9e/docker/bin/snapcraft-wrapper /snap/bin/snapcraft
 RUN sed -i -e "s@\"amd64\"@$ARCH@" /snap/bin/snapcraft && chmod +x /snap/bin/snapcraft
 
-# snapcraft will be in /snap/bin, so we need to put that on the $PATH
+# Snapcraft will be in /snap/bin, so we need to put that on the $PATH
 ENV PATH=/snap/bin:$PATH
 
-# include all of the build context inside /build
+# Include all of the build context inside /build
 COPY . /build
 
-# run the entrypoint.sh script to actually perform the build when the container is run
+# Run the entrypoint.sh script to actually perform the build when the 
+# container is run
 WORKDIR /build
 ENTRYPOINT [ "/build/snap/entrypoint.sh" ]
 EOF
 
-# delete the login file we copied to the git root so it doesn't persist around
+# Always delete the login file we copied to the git root so it doesn't persist
 rm "$GIT_ROOT/edgex-snap-store-login"
 
-# now run the build with the environment variables 
+# Finally, run the build with the environment variables 
 docker run --rm \
     -e "JOB_TYPE=$JOB_TYPE" \
     -e "SNAP_REVISION=$SNAP_REVISION" \
@@ -171,5 +180,6 @@ docker run --rm \
     -e "SNAP_NAME=$SNAP_NAME" \
     edgex-snap-builder:latest
 
-# note that we don't need to delete the docker images here, that's done for us by jenkins in the 
-# edgex-provide-docker-cleanup macro defined for all the snap jobs
+# Note that we don't need to delete the docker images here, that's done for us
+# by jenkins in the edgex-provide-docker-cleanup macro defined for all the 
+# snap jobs

--- a/shell/edgexfoundry-snapcraft.sh
+++ b/shell/edgexfoundry-snapcraft.sh
@@ -1,0 +1,175 @@
+#!/bin/bash -x
+
+# note that since this script gets included into a yaml string using jjb's
+# include-raw-escape macro, we can't use any squiggly braces here, otherwise
+# they will get duplicated
+# for some reason we also can't use include-raw macro because that macro will
+# attempt to interpret anything contianed in a macro as a jenkins key to
+# expand which we also don't want
+
+# if we are running inside a jenkins instance then copy the login file 
+# and check if this is a release job
+if [ -n "$JENKINS_URL" ]; then
+    # since we are running from jenkins, use the workspace as the git root
+    GIT_ROOT=$WORKSPACE
+    if [ -f "$HOME/EdgeX" ]; then
+       cp "$HOME/EdgeX" "$GIT_ROOT/edgex-snap-store-login"
+    else
+        echo "I seem to be running on Jenkins, but there's not a snap store login file..." 
+    fi
+
+    # figure out what kind of job this is using $JOB_NAME and simplify that 
+    # into $JOB_TYPE
+    if [[ "$JOB_NAME" =~ .*-snap-.*-stage-snap.* ]]; then
+        JOB_TYPE="stage"
+    elif [[ "$JOB_NAME" =~ .*-snap-release-snap ]]; then
+        JOB_TYPE="release"
+    else
+        JOB_TYPE="build"
+    fi
+else
+    # not running in a jenkins container, assume the current working directory
+    # is the repo git dir that we want
+    GIT_ROOT=$PWD
+fi
+
+# find the name of this snap from the snapcraft.yaml "name" key
+# note that we assume that snapcraf.yaml is located in snap/snapcraft.yaml 
+# but it is technically allowed to store it in other locations, we just don't
+# support that here
+# TODO: implement better handling of snapcraft.yaml file discovery
+SNAP_NAME=$(grep -Po '^name: \K(.*)' snap/snapcraft.yaml)
+
+# save the entrypoint.sh script inside the build context we will send to docker
+# we have to do this because the dockerfile needs access to that file from it's
+# build context, so either we download the entrypoint script, or we include it
+# into the filesystem build context. downloading isn't great because then 
+# there's additional linkages between this script and wherever we download from
+# and it gets complicated to manage that
+# we save it at snap/entrypoint.sh
+(
+cat <<'EOF'
+#!/bin/bash -e
+
+# Required by click.
+export LC_ALL=C.UTF-8
+export SNAPCRAFT_SETUP_CORE=1
+
+# this tells snapcraft to include a manifest file in the snap
+# detailing which packages were used to build the snap
+export SNAPCRAFT_BUILD_INFO=1
+
+# if snapcraft ever encounters any bugs, we should force it to 
+# auto-report silently rather than attempt to ask for permission
+# to send a report
+export SNAPCRAFT_ENABLE_SILENT_REPORT=1
+
+case "$JOB_TYPE" in 
+    "stage")
+        # stage jobs build the snap locally and release it
+        pushd /build > /dev/null
+        snapcraft clean
+        snapcraft
+        popd > /dev/null
+        pushd /build > /dev/null
+        snapcraft login --with /build/edgex-snap-store-login
+        # push the snap up to the store and get the revision of the snap
+        REVISION=$(snapcraft push "$SNAP_NAME"*.snap | grep -Po 'Revision \K[0-9]+')
+        # now release it on the provided revision and snap channel
+        snapcraft release "$SNAP_NAME" "$REVISION" "$SNAP_CHANNEL" 
+        # also update the meta-data automatically
+        snapcraft push-metadata "$SNAP_NAME"*.snap --force
+        popd > /dev/null
+    ;;
+    "release")
+        # release jobs will promote an already built snap revision
+        # in the store to a channel
+        snapcraft login --with /build/edgex-snap-store-login
+        snapcraft release "$SNAP_NAME" "$SNAP_REVISION" "$SNAP_CHANNEL"
+    ;;
+    *)
+        # do normal build and nothing else
+        pushd /build > /dev/null
+        snapcraft clean
+        snapcraft
+        popd > /dev/null
+
+    ;;
+esac
+
+EOF
+) > "$GIT_ROOT/snap/entrypoint.sh"
+
+chmod +x "$GIT_ROOT/snap/entrypoint.sh"
+
+# build the container image - providing the relevant architecture we're on
+# to determine which snap arch to download in the docker container
+case $(arch) in 
+    x86_64)
+        arch="amd64";;
+    aarch64)
+        arch="arm64";;
+    arm*)
+        arch="armhf";;
+esac
+docker build -t edgex-snap-builder:latest --build-arg ARCH="$arch" "$GIT_ROOT" -f- <<'EOF'
+FROM ubuntu:18.04
+
+# allow specifying the architecture from the build arg command line
+ARG ARCH
+
+# this is essentially the same as the upstream dockerfile
+# here: https://github.com/snapcore/snapcraft/blob/master/docker/stable.Dockerfile
+# except we also specify the architecture to download so that this works
+# on other architectures
+# basically, we send a command to the snap store for the info on the core +
+# snapcraft snaps, extract the download link from the result and 
+# download and extract the snaps into the docker container
+# we do this because we can't easily run snapd (and thus snaps) inside a docker
+# container without disabling important security protections enabled for 
+# docker containers
+RUN apt-get update && \
+    apt-get dist-upgrade --yes && \
+    apt-get install --yes \
+    curl sudo jq squashfs-tools && \
+    curl -s -L $(curl -s -H 'X-Ubuntu-Series: 16' -H "X-Ubuntu-Architecture: $ARCH" 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap && \
+    mkdir -p /snap/core && unsquashfs -n -d /snap/core/current core.snap && rm core.snap && \
+    curl -s -L $(curl -s -H 'X-Ubuntu-Series: 16' -H "X-Ubuntu-Architecture: $ARCH" 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft' | jq '.download_url' -r) --output snapcraft.snap && \
+    mkdir -p /snap/snapcraft && unsquashfs -n -d /snap/snapcraft/current snapcraft.snap && rm snapcraft.snap && \
+    apt remove --yes --purge curl jq squashfs-tools && \
+    apt-get autoclean --yes && \
+    apt-get clean --yes
+
+# the upstream dockerfile just uses this file locally from the repo, but 
+# rather than copy that file into this repo, we can just download it here
+# while unlikely it is possible that the file location could move in the git repo
+# on master branch, so for stability in our builds, we just hard-code the git 
+# commit that most recently updated this file as the revision to download from
+# if this ever breaks, just change this file to copy what the upstream master dockerfile does
+ADD https://raw.githubusercontent.com/snapcore/snapcraft/25043ab3667d24688b3d93dcac9f9a74f35dae9e/docker/bin/snapcraft-wrapper /snap/bin/snapcraft
+RUN sed -i -e "s@\"amd64\"@$ARCH@" /snap/bin/snapcraft && chmod +x /snap/bin/snapcraft
+
+# snapcraft will be in /snap/bin, so we need to put that on the $PATH
+ENV PATH=/snap/bin:$PATH
+
+# include all of the build context inside /build
+COPY . /build
+
+# run the entrypoint.sh script to actually perform the build when the container is run
+WORKDIR /build
+ENTRYPOINT [ "/build/snap/entrypoint.sh" ]
+EOF
+
+# delete the login file we copied to the git root so it doesn't persist around
+rm "$GIT_ROOT/edgex-snap-store-login"
+
+# now run the build with the environment variables 
+docker run --rm \
+    -e "JOB_TYPE=$JOB_TYPE" \
+    -e "SNAP_REVISION=$SNAP_REVISION" \
+    -e "SNAP_CHANNEL=$SNAP_CHANNEL" \
+    -e "SNAP_NAME=$SNAP_NAME" \
+    edgex-snap-builder:latest
+
+# note that we don't need to delete the docker images here, that's done for us by jenkins in the 
+# edgex-provide-docker-cleanup macro defined for all the snap jobs


### PR DESCRIPTION
This PR generalizes the snap build scripts we have from edgex-go(see [here](https://github.com/edgexfoundry/edgex-go/blob/master/snap/build.sh), [here](https://github.com/edgexfoundry/edgex-go/blob/master/snap/entrypoint.sh), and [here](https://github.com/edgexfoundry/edgex-go/blob/master/snap/Dockerfile.build)) and stores it all in the jenkins job definition directly as the `build_script` so that when we add more repositories, it's easy to create an associated snap job as well by just templating out the job definitions for that project/repo and specifying the `{project-name}-{stream}-stage-snap` and `{project-name}-{stream}-verify-snap`, etc. 

I deployed this job on the sandbox and was able to build the associated edgex-go PR https://github.com/edgexfoundry/edgex-go/pull/1297 successfully. See https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-go-snap-master-verify-snap/1/console. I did modify the job definition slightly by removing the macro which adds the snapcraft credentials to the job when running because those credentials aren't available to the sandbox jenkins and they're not really needed to test the job at all. The patch is here if anyone wants to mess around with the sandbox job definition:
```patch
diff --git a/jjb/edgex-templates-snap.yaml b/jjb/edgex-templates-snap.yaml
index 20299d7..b6cee40 100644
--- a/jjb/edgex-templates-snap.yaml
+++ b/jjb/edgex-templates-snap.yaml
@@ -45,7 +45,7 @@
           files:
             - file-id: netrc
               target: '$HOME/.netrc'
-      - edgex-snap-wrapper
+      # - edgex-snap-wrapper
 
     publishers:
       - lf-infra-publish
```

The `edgexfoundry-snapcraft.sh` script we have here is not ideal, as it uses 2 heredocs to basically store 2 other scripts inside the single script so that all of that is available from the job definition directly, but here's the reasoning for why I did that:
* The Dockerfile is okay to store in the script and feed via stdin to the `docker build` process because docker build supports stdin input of the Dockerfile. This doesn't pose any complications or differences in how the docker container is built or runs. We currently need to include all of the files from the project into the docker container as well as the credentials file so that when the build is finished, the snap artifacts don't leave the container and just get pushed into the store when successful. We could use volumes but I was told that this was complicated to setup such that SELinux allowed the mounts to happen and that it was better to just inject all the files we need during the build into the container image. 
* The entrypoint.sh script is a bit more difficult because we need that script to be available to docker as part of it's build context somehow when the container is being built. We can't just store the entrypoint.sh somewhere in /tmp, etc. as it needs to be accessible inside the container. We could have the Dockerfile download the entrypoint.sh script from somewhere (perhaps even this repository), but that leads to complicated syncing problems especially when modifying that file, as you need to update the file in a way that the build when it runs to test actually is able to download that file. As such, the temporary best option is to just store that file inside the build context directly by saving the file into `$GIT_ROOT/snap/entrypoint.sh`.

I also ran into a bit of difficulty with the `edgexfoundry-snapcraft.sh` script and the `entrypoint.sh` heredoc, where the original entrypoint.sh had functions defined for various things and just called those bash functions, but I couldn't figure out how to escape the necessary `{` and `}` characters in such a way that the function definitions were still valid bash and allowed as valid job definition YAML. If I used the `include-raw` macro, it would fail to generate the job definition because it would treat the function definition body as a key to replace with a jenkins job builder variable, so I had to use `{{` and `}}` in the file to generate the appropriate job definition, but then the `{{` weren't re-replaced to be just `{` again and so it wasn't a valid bash script... I also tried numerous ways of escaping the `{` with the `include-raw-escape` macro and everytime the `{` would get replaced into `{{`, so in the end I just removed the functions and called the code directly wherever I needed to use the function. It's not great but it works.

I also setup the delhi override successfully such that we won't need to backport these changes to delhi and delhi jobs can continue to build using the build.sh script present in that repo. You can see that job on the sandbox here: https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-go-snap-delhi-stage-snap/1/console (but not the job itself is marked as failure only because it couldn't actually release the snap)

Note that I think we should merge this into ci-management before merging the edgex-go PR so that the edgex-go PR can actually use these job definitions to test those changes.

Finally, I also fixed some typos here and removed the redundant "snap" in the arm verify job name.