### PR TITLE
jjb/ui/edgex-ui-go.yaml: use custom go on master job definition

### DIFF
--- a/jjb/ui/edgex-ui-go.yaml
+++ b/jjb/ui/edgex-ui-go.yaml
@@ -9,6 +9,9 @@
     stream:
       - 'master':
           branch: 'master'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          build_script: 'make test && make build docker'
+          go-root: '/opt/go-custom/go'
       - 'delhi':
           branch: 'delhi'
     jobs:


### PR DESCRIPTION
This allows go modules to work properly

Fixes #356

I deployed this on the sandbox here: https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-ui-go-master-verify-go/7/ where I was able to get the verify job to work properly for https://github.com/edgexfoundry/edgex-ui-go/pull/87 meaning that with this PR merged and with that PR merged, jenkins verify jobs should resume working for that repository again