### PR TITLE
Add github webhook workaround for pipeline jobs

### DIFF
--- a/jjb/build-images/build-images.yml
+++ b/jjb/build-images/build-images.yml
@@ -19,3 +19,5 @@
     jobs:
       - '{project-name}-{stream}-verify-pipeline'
       - '{project-name}-{stream}-merge-pipeline'
+      - '{project-name}-pipeline-webhooks':
+        status-context: '{project-name}-pipeline-webhooks'

--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -97,6 +97,71 @@
       # no reason to add github-pull-request here since it doesn't currently
       # work for merge / push
 
+- pipeline_webhooks_boiler_plate: &pipeline_webhooks_boiler_plate
+    # Freestyle job to have jenkins create and maintain the github push 
+    # webhook. Currently the github jenkins plugin cannot create the push 
+    # webhook using the pipeline scm section of the job.
+    # This job is meant to be a no op.
+
+    name: pipeline_webhooks_boiler_plate
+
+    project-type: freestyle
+    node: '{build-node}'
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+    submodule-recursive: true
+    status-context: ''
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    properties:
+      - lf-infra-properties:
+          project: '{project}'
+          build-days-to-keep: '{build-days-to-keep}'
+      - github:
+          url: '{git-url}/{github-org}/{project}'
+
+    parameters:
+      - lf-infra-parameters:
+          project: '{project}'
+          branch: '{branch}'
+          stream: ''
+          lftools-version: '{lftools-version}'
+
+    scm:
+      - lf-infra-github-scm:
+          url: '{git-clone-url}{github-org}/{project}'
+          refspec: ''
+          branch: 'refs/heads/{branch}'
+          submodule-recursive: '{submodule-recursive}'
+          choosing-strategy: default
+          jenkins-ssh-credential: '{jenkins-ssh-credential}'
+          submodule-timeout: 10
+
+    wrappers:
+      - lf-infra-wrappers:
+          build-timeout: '{build-timeout}'
+          jenkins-ssh-credential: '{jenkins-ssh-credential}'
+      - config-file-provider:
+          files:
+            - file-id: netrc
+              target: '$HOME/.netrc'
+
+    publishers:
+      - lf-infra-publish
+
+    triggers:
+      - github
+      - pollscm:
+          cron: ''
+      # no reason to add github-pull-request here since it doesn't currently
+      # work for merge / push
 
 # Job Templates
 
@@ -143,3 +208,16 @@
     <<: *pipeline_merge_boiler_plate
 
     build-node: centos7-docker-4c-2g
+
+- job-template:
+    name: '{project-name}-pipeline-webhooks'
+
+    <<: *pipeline_webhooks_boiler_plate
+
+    build-node: centos7-docker-4c-2g
+
+    builders:
+      - lf-provide-maven-settings:
+          global-settings-file: 'global-settings'
+          settings-file: '{mvn-settings}'
+      - shell: 'ls'


### PR DESCRIPTION
After researching the Jenkins Github plugin and learning the limitations of it. Basically, it is unable to use the SCM block in a pipeline job to register the Github webhook. One of the workarounds I had was just to create a freestyle job that has no operation other than to register the webhook.

I've put this job up on the sandbox and it tries to register the webhook but is unable to. I suspect this is because the settings files on the sandbox don't have the correct permissions for Github.

The configuration for this job is here:
https://jenkins.edgexfoundry.org/sandbox/view/All/job/ci-build-images-pipeline-webhooks/configure

Let me know what y'all think.

@MightyNerdEric @dweomer @ernestojeda 

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>