### PR TITLE
Add device-modbus snap jobs

### DIFF
--- a/jjb/device/device-modbus-go-snap.yaml
+++ b/jjb/device/device-modbus-go-snap.yaml
@@ -1,0 +1,24 @@
+---
+- project:
+    name: device-modbus-go-snap
+    project-name: device-modbus-go-snap
+    project: device-modbus-go
+    mvn-settings: device-modbus-go-settings
+    stream:
+      - 'master':
+          branch: 'master'
+          snap-channel: latest/edge
+
+    jobs:
+     - '{project-name}-{stream}-stage-snap-arm':
+         build-node: ubuntu18.04-docker-arm64-4c-2g
+     - '{project-name}-release-snap':
+         build-node: centos7-docker-4c-2g
+     - '{project-name}-{stream}-stage-snap':
+         build-node: centos7-docker-4c-2g
+     - '{project-name}-{stream}-verify-snap-arm':
+         build-node: ubuntu18.04-docker-arm64-4c-2g
+         status-context: '{project-name}-{stream}-verify-arm'
+     - '{project-name}-{stream}-verify-snap':
+         build-node: centos7-docker-4c-2g
+         status-context: '{project-name}-{stream}-verify'


### PR DESCRIPTION
This adds verify, stage, and release jobs for device-modbus for the snap. Currently only enable for master branch, we won't release the snap for delhi.

I have uploaded the jobs to the sandbox and attempted to run what I could.

For the verify jobs, I am running the sandbox jobs against https://github.com/edgexfoundry/device-modbus-go/pull/47 :
- https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/device-modbus-go-snap-master-verify-snap-arm/
- https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/device-modbus-go-snap-master-verify-snap/

The stage jobs failed because the changes in the previously mentioned PR haven't been merged to master. I tried running the build with the sha1 parameter to use the github PR branch, but that didn't seem to work. See those jobs here:
- https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/device-modbus-go-snap-master-stage-snap/
- https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/device-modbus-go-snap-master-stage-snap-arm/

I am thinking it might be easier to merge this PR first, then have the verify jobs run against the device-modbus PR, merge that, then after the master branch of device-modbus has the changes just revisit any problems with the stage jobs then.

I did not test/upload the release job as it's not really testable on the sandbox.

