### PR TITLE
Update centos7-builder image, remove basebuild

### DIFF
--- a/jenkins-config/clouds/openstack/Primary/centos7-basebuild-2c-1g.cfg
+++ b/jenkins-config/clouds/openstack/Primary/centos7-basebuild-2c-1g.cfg
@@ -1,2 +1,0 @@
-IMAGE_NAME=CentOS 7 - basebuild - 20180207-0123
-HARDWARE_ID=v1-standard-1

--- a/jenkins-config/clouds/openstack/Primary/centos7-builder-2c-1g.cfg
+++ b/jenkins-config/clouds/openstack/Primary/centos7-builder-2c-1g.cfg
@@ -1,2 +1,2 @@
-IMAGE_NAME=ZZCI - CentOS 7 - builder - 20180320-0236
+IMAGE_NAME=ZZCI - CentOS 7 - builder - x86_64 - 20190515-024645.138
 HARDWARE_ID=v1-standard-1

--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    build-node: centos7-basebuild-2c-1g
     jobs:
       - '{project-name}-github-ci-jobs'
       - github-packer-verify

--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -16,7 +16,7 @@
 
     # Timeout in minutes
     build-timeout: 360
-    build-node: centos7-basebuild-2c-1g
+    build-node: centos7-builder-2c-1g
 
     archive-artifacts: ''
 


### PR DESCRIPTION
centos7-builder and centos7-basebuild were both very out of date.
Builder is meant to replace basebuild, and basebuild is not in use
in any job, so it has been entirely removed from the repo.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>