### PR TITLE
Adding schedule on performance-test job

### DIFF
--- a/jjb/edgex-templates-performance.yaml
+++ b/jjb/edgex-templates-performance.yaml
@@ -97,8 +97,10 @@
           choosing-strategy: default
           jenkins-ssh-credential: '{jenkins-ssh-credential}'
           submodule-timeout: 10
+          
+    triggers:
+      - timed: 'H 4 * * 6'
 
-# Job Templates
 
 - job-template:
     name: 'performance-test-{stream}'


### PR DESCRIPTION
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
The performance-test job will trigger at every Saturday 4 AM UTC time.
Fix #375 
