### PR TITLE
Issue 363: Update go version of security-secret-store build to match device services

### DIFF
--- a/jjb/security/security-secret-store.yaml
+++ b/jjb/security/security-secret-store.yaml
@@ -20,18 +20,12 @@
 
     jobs:
       - '{project-name}-{stream}-verify-go'
-      - '{project-name}-{stream}-verify-go-arm':
-          golang_arm_script: !include-raw-escape: shell/install_arm_golang.sh
-          go-root: '/opt/go1105/go'
+      - '{project-name}-{stream}-verify-go-arm'
       - '{project-name}-{stream}-merge-go':
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
       - '{project-name}-{stream}-merge-go-arm':
-          go-root: '/opt/go1105/go'
-          golang_arm_script: !include-raw-escape: shell/install_arm_golang.sh
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
       - '{project-name}-{stream}-stage-go':
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh
       - '{project-name}-{stream}-stage-go-arm':
-          go-root: '/opt/go1105/go'
-          golang_arm_script: !include-raw-escape: shell/install_arm_golang.sh
           post_build_script: !include-raw-escape: shell/security-secret-store-go-docker-push.sh


### PR DESCRIPTION
Fix #363

Install go_custom_golang.sh will install a newer version of golang than this script. This will make security-secret-store match the other device services golang version in builds.

Perhaps hold off until Edinburgh release is cut. @anonymouse64 what are your thoughts?

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>