### PR TITLE
add device-snmp-go pipeline job

### DIFF
--- a/jjb/device/device-snmp-go.yaml
+++ b/jjb/device/device-snmp-go.yaml
@@ -1,0 +1,16 @@
+---
+
+- project:
+    name: device-snmp-go
+    project-name: device-snmp-go
+    project: device-snmp-go
+    mvn-settings: device-snmp-go-settings
+    jenkins_file: 'Jenkinsfile'
+    status-context: '{project-name}-verify-pipeline'
+    stream: {}
+
+    jobs:
+      - '{project-name}-verify-pipeline'
+      - '{project-name}-merge-pipeline'
+      - '{project-name}-pipeline-webhooks':
+        status-context: '{project-name}-pipeline-webhooks'


### PR DESCRIPTION
This will fail after merge unless edgexfoundry/device-snmp-go#7 is merged first.

Working on sandbox testing, will update this with its G2G.

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>