### PR TITLE
edgexfoundry-snapcraft.sh: use --release option to push

### DIFF
--- a/shell/edgexfoundry-snapcraft.sh
+++ b/shell/edgexfoundry-snapcraft.sh
@@ -75,10 +75,9 @@ case "$JOB_TYPE" in
         popd > /dev/null
         pushd /build > /dev/null
         snapcraft login --with /build/edgex-snap-store-login
-        # Push the snap up to the store and get the revision of the snap
-        REVISION=$(snapcraft push "$SNAP_NAME"*.snap | grep -Po 'Revision \K[0-9]+')
-        # Now release it on the provided revision and snap channel
-        snapcraft release "$SNAP_NAME" "$REVISION" "$SNAP_CHANNEL" 
+        # Push the snap up to the store and release it on the specified
+        # channel
+        snapcraft push "$SNAP_NAME"*.snap --release "$SNAP_CHANNEL" 
         # Also force an update of the meta-data
         snapcraft push-metadata "$SNAP_NAME"*.snap --force
         popd > /dev/null


### PR DESCRIPTION
This should at least show us in the jenkins job output the full output
of `snapcraft push` and help identify failures to release or failures to
upload.

It also guards us against future changes in the output of
`snapcraft push`.

This will help in debugging the real failure behind jobs such as https://jenkins.edgexfoundry.org/view/Snap/job/edgex-go-snap-master-stage-snap/359/ even though it may not actually solve the build failure as we will be able to see the full output from `snapcraft push` without it going through grep.

Also I didn't deploy this to the sandbox because the sandbox doesn't have the necessary credentials in order to accurately test the stage job, but if desired I can try to hack around that.