### PR TITLE
update release stream jobs for device-snmp-go

### DIFF
--- a/jjb/device/device-snmp-go.yaml
+++ b/jjb/device/device-snmp-go.yaml
@@ -7,10 +7,14 @@
     mvn-settings: device-snmp-go-settings
     jenkins_file: 'Jenkinsfile'
     status-context: '{project-name}-verify-pipeline'
-    stream: {}
+    stream:
+      - 'master':
+          branch: 'master'
+      - 'edinburgh':
+          branch: 'edinburgh'
 
     jobs:
       - '{project-name}-verify-pipeline'
-      - '{project-name}-merge-pipeline'
+      - '{project-name}-{stream}-merge-pipeline'
       - '{project-name}-pipeline-webhooks':
         status-context: '{project-name}-pipeline-webhooks'


### PR DESCRIPTION
This corrects the job definition for `device-snmp-go` to have jobs for both `master` and `edinburgh` branches.

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>