### PR TITLE
Add codecov.io to edgex-go merge jobs

### DIFF
--- a/jjb/edgex-go/edgex-go.yaml
+++ b/jjb/edgex-go/edgex-go.yaml
@@ -28,9 +28,13 @@
           status-context: '{project-name}-{stream}-verify-arm'
           post_build_script: !include-raw-escape: shell/codecov-uploader.sh
       - '{project-name}-{stream}-merge-go':
-          post_build_script: !include-raw-escape: shell/edgexfoundry-go-docker-push.sh
+          post_build_script: !include-raw-escape: 
+            - shell/edgexfoundry-go-docker-push.sh
+            - shell/codecov-uploader.sh
       - '{project-name}-{stream}-merge-go-arm':
-          post_build_script: !include-raw-escape: shell/edgexfoundry-go-docker-push.sh
+          post_build_script: !include-raw-escape: 
+            - shell/edgexfoundry-go-docker-push.sh
+            - shell/codecov-uploader.sh
       - '{project-name}-{stream}-stage-go':
           post_build_script: !include-raw-escape: shell/edgexfoundry-go-docker-push.sh
       - '{project-name}-{stream}-stage-go-arm':


### PR DESCRIPTION
This adds the codecov.io uploader to the end of the merge job for edgex-go.

See sandbox job:
https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-go-master-merge-go/

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>