### PR TITLE
edgex-ui-go-snap.yaml: add snap jobs for edgex-go-ui

### DIFF
--- a/jjb/ui/edgex-ui-go-snap.yaml
+++ b/jjb/ui/edgex-ui-go-snap.yaml
@@ -1,0 +1,26 @@
+---
+- project:
+    name: edgex-ui-go-snap
+    project-name: edgex-ui-go-snap
+    project: edgex-ui-go
+    mvn-settings: edgex-ui-go-settings
+    stream:
+      - 'master':
+          branch: 'master'
+          snap-channel: latest/edge
+      - 'edinburgh':
+          branch: 'edinburgh'
+          snap-channel: edinburgh/edge
+    jobs:
+     - '{project-name}-{stream}-stage-snap-arm':
+         build-node: ubuntu18.04-docker-arm64-4c-2g
+     - '{project-name}-release-snap':
+         build-node: centos7-docker-4c-2g
+     - '{project-name}-{stream}-stage-snap':
+         build-node: centos7-docker-4c-2g
+     - '{project-name}-{stream}-verify-snap-arm':
+         build-node: ubuntu18.04-docker-arm64-4c-2g
+         status-context: '{project-name}-{stream}-verify-arm'
+     - '{project-name}-{stream}-verify-snap':
+         build-node: centos7-docker-4c-2g
+         status-context: '{project-name}-{stream}-verify'


### PR DESCRIPTION
This adds snap jobs for edgex-ui-go. I deployed to the sandbox the verify jobs and confirmed they worked when run against this PR to edgex-ui-go: https://github.com/edgexfoundry/edgex-ui-go/pull/112

The x86 verify snap job: https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/edgex-ui-go-snap-master-verify-snap/
The arm64 verify snap job: https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/edgex-ui-go-snap-master-verify-snap-arm/

I didn't test the release or stage jobs because they won't work on the sandbox without the snap store credentials file.

~~Opening as a draft until the jobs actually finish successfully~~ - both jobs have now successfully completed