### PR TITLE
build(app-functions): Remove pre-build script for app functions master branch

### DIFF
--- a/jjb/app-functions/app-functions-sdk-go.yaml
+++ b/jjb/app-functions/app-functions-sdk-go.yaml
@@ -10,7 +10,6 @@
     stream:
       - 'master':
           branch: 'master'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           build_script: 'make test && make build docker'
           go-root: '/opt/go-custom/go'
       - 'edinburgh':


### PR DESCRIPTION
As we move to making go 1.12 a requirement, tests are failing due to `shell/install_custom_golang.sh` installing 1.11.5. In talking to @lranjbar, removing this `pre_build_script`, should resolve the failure for new pull requests coming into `master` for app functions as it will install go 1.12.

Fixes #419 

Signed-off-by: Mike Johanson <michael.johanson@intel.com>