### PR TITLE
use edgex-ui-go-settings to verify pipeline

### DIFF
--- a/jjb/ui/edgex-ui-clojure.yaml
+++ b/jjb/ui/edgex-ui-clojure.yaml
@@ -3,7 +3,7 @@
     name: edgex-ui-clojure
     project-name: edgex-ui-clojure
     project: edgex-ui-clojure
-    mvn-settings: edgex-ui-clojure-settings
+    mvn-settings: edgex-ui-go-settings
     jenkins_file: 'Jenkinsfile'
     status-context: '{project-name}-{stream}-verify-pipeline'
     stream:


### PR DESCRIPTION
There seems to be an issue with the `edgex-ui-clojure-settings` file. I am updating the build to use the `edgex-ui-go-settings` to verify that there are no issues with the actual pipeline. Will revert after.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>