### PR TITLE
Fix edgex-ui-go staging jobs

### DIFF
--- a/shell/edgexfoundry-edgex-ui-go-push.sh
+++ b/shell/edgexfoundry-edgex-ui-go-push.sh
@@ -63,7 +63,7 @@ done
 mkdir -p edgex-ui-go-$VERSION
 bin_dir=edgex-ui-go-$VERSION/
 
-go_bins=(cmd/edgex-ui-go/edgex-ui-go)
+go_bins=(cmd/edgex-ui-server/edgex-ui-server)
 
 for bin in "${go_bins[@]}"; do
   cp $bin $bin_dir


### PR DESCRIPTION
Looks like the staging jobs for edgex-ui-go are broken due to a rename of the folders back in April.

https://github.com/edgexfoundry/edgex-ui-go/commit/9320ba4302d69343b70f687de956b4885acb3609#diff-b67911656ef5d18c4ae36cb6741b7965

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>