### PR TITLE
Add jobs for device-grove snap

### DIFF
--- a/jjb/device/device-grove-c-snap.yaml
+++ b/jjb/device/device-grove-c-snap.yaml
@@ -1,0 +1,27 @@
+---
+- project:
+    name: device-grove-c-snap
+    project-name: device-grove-c-snap
+    project: device-grove-c
+    mvn-settings: device-grove-c-settings
+    stream:
+      - 'master':
+          branch: 'master'
+          snap-channel: latest/edge
+      - 'edinburgh':
+          branch: 'edinburgh'
+          snap-channel: edinburgh/edge
+
+    jobs:
+     - '{project-name}-{stream}-stage-snap-arm':
+         build-node: ubuntu18.04-docker-arm64-4c-2g
+     - '{project-name}-release-snap':
+         build-node: centos7-docker-4c-2g
+     - '{project-name}-{stream}-stage-snap':
+         build-node: centos7-docker-4c-2g
+     - '{project-name}-{stream}-verify-snap-arm':
+         build-node: ubuntu18.04-docker-arm64-4c-2g
+         status-context: '{project-name}-{stream}-verify-arm'
+     - '{project-name}-{stream}-verify-snap':
+         build-node: centos7-docker-4c-2g
+         status-context: '{project-name}-{stream}-verify'


### PR DESCRIPTION
This was deployed to the sandbox to test the verify jobs with this PR [here](https://github.com/edgexfoundry/device-grove-c/pull/15):

* https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/device-grove-c-snap-master-verify-snap-arm/1/console
* https://jenkins.edgexfoundry.org/sandbox/view/Snap/job/device-grove-c-snap-master-verify-snap/1/console

The jobs were deployed without the edgex credentials.
The snap and stage jobs weren't deployed due to the complications from the edgex snap store credentials, but like all the other snap jobs if the verify one works the stage jobs should work literally almost exactly the same.