### PR TITLE
Add docker build to device-snmp staging jobs

### DIFF
--- a/jjb/device/device-snmp-go.yaml
+++ b/jjb/device/device-snmp-go.yaml
@@ -10,8 +10,14 @@
     stream:
       - 'master':
           branch: 'master'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          build_script: 'make test && make build docker'
+          go-root: '/opt/go-custom/go'
       - 'edinburgh':
           branch: 'edinburgh'
+          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
+          build_script: 'make test && make build docker'
+          go-root: '/opt/go-custom/go'
 
     jobs:
       - '{project-name}-verify-pipeline'


### PR DESCRIPTION
It looks like the current staging jobs are failing because we aren't building docker images earlier in the job. I'm running these changes on the sandbox but it is hard to tell if they will work on production. (Failures happen on sandbox because of mocked out credentials)

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>