### PR TITLE
Add Sonarcloud base links

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -54,3 +54,7 @@
     staging-profile-id: a004df83a6249
     mvn-staging-id: staging
     nexus-snapshot-repo: snapshots
+
+    # Sonarcloud
+    sonarcloud_project_organization: edgexfoundry
+    sonarcloud_api_token: 3e68831b5a5b2b70a5c6698c8f6878f251c1ee97


### PR DESCRIPTION
Configure the common Sonarcloud variables. Projects desiring to run
scans will still need to configure the project-key.

Issue: LFJIRA IT-16663
Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>