### PR TITLE
Remove centos-7-arm64 builds from packer.yaml

### DIFF
--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -14,7 +14,6 @@
 
     platforms:
       - centos-7
-      - centos-7-arm64
       - ubuntu-16.04
       - ubuntu-18.04-arm64
     templates: builder
@@ -34,7 +33,6 @@
 
     platforms:
       - centos-7
-      - centos-7-arm64
       - ubuntu-16.04
       - ubuntu-18.04-arm64
     templates: docker


### PR DESCRIPTION
These are not being used, and the Vexxhost images are not working
properly, causing the jobs to always fail.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>