### PR TITLE
optimized LFtools log publishing process for all edgex freestyle jobs

### DIFF
--- a/jjb/edgex-macros.yaml
+++ b/jjb/edgex-macros.yaml
@@ -8,6 +8,48 @@
           notify-every-unstable-build: true
           send-to-individuals: false
 
+- publisher:
+    name: edgex-infra-publish
+    # macro to finish up a build - copy of lfit lf-infra-publish macro but using
+    # edgex-infra-ship-logs builder to ship logs to nexus via python3-based docker image
+    #
+    # Handles the following:
+    #   - Shipping logs to Nexus logs site repository
+    #   - Cleanup workspace
+    publishers:
+      - postbuildscript:
+          builders:
+            - role: BOTH
+              build-on:
+                - ABORTED
+                - FAILURE
+                - NOT_BUILT
+                - SUCCESS
+                - UNSTABLE
+              build-steps:
+                - lf-infra-sysstat
+                - lf-infra-package-listing
+                - edgex-infra-ship-logs
+          mark-unstable-if-failed: true
+      - workspace-cleanup:
+          exclude:
+            # Do not clean up *.jenkins-trigger files for jobs that use a
+            # properties file as input for triggering another build.
+            - '**/*.jenkins-trigger'
+          fail-build: false
+
+- builder:
+    name: edgex-infra-ship-logs
+    builders:
+      - config-file-provider:
+          files:
+            - file-id: 'jenkins-log-archives-settings'
+              variable: 'SETTINGS_FILE'
+      - shell: !include-raw:
+          - ../shell/edgex-infra-ship-logs.sh
+      - description-setter:
+          regexp: '^Build logs: .*'
+
 - builder:
     name: edgex-provide-docker-cleanup
     builders:

--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -49,7 +49,7 @@
           jenkins-ssh-credential: '{jenkins-ssh-credential}'
 
     publishers:
-      - lf-infra-publish
+      - edgex-infra-publish
 
 - docker_verify_boiler_plate: &docker_verify_boiler_plate
     name: docker_verify_boiler_plate

--- a/jjb/edgex-templates-docs.yaml
+++ b/jjb/edgex-templates-docs.yaml
@@ -46,7 +46,7 @@
               target: '$HOME/.netrc'
 
     publishers:
-      - lf-infra-publish
+      - edgex-infra-publish
       - edgex-jenkins-alerts
 
 - docs_verify_boiler_plate: &docs_verify_boiler_plate

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -49,7 +49,7 @@
               target: '$HOME/.netrc'
 
     publishers:
-      - lf-infra-publish
+      - edgex-infra-publish
       - edgex-jenkins-alerts
 
 - go_verify_boiler_plate: &go_verify_boiler_plate

--- a/jjb/edgex-templates-integration.yaml
+++ b/jjb/edgex-templates-integration.yaml
@@ -41,7 +41,7 @@
           jenkins-ssh-credential: '{jenkins-ssh-credential}'
 
     publishers:
-      - lf-infra-publish
+      - edgex-infra-publish
       - edgex-jenkins-alerts
 
 - integration_verify_boiler_plate: &integration_verify_boiler_plate

--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -37,7 +37,7 @@
           jenkins-ssh-credential: '{jenkins-ssh-credential}'
 
     publishers:
-      - lf-infra-publish
+      - edgex-infra-publish
 
 - verify_boiler_plate: &verify_boiler_plate
     name: verify_boiler_plate

--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -155,7 +155,7 @@
               target: '$HOME/.netrc'
 
     publishers:
-      - lf-infra-publish
+      - edgex-infra-publish
 
     triggers:
       - github

--- a/jjb/edgex-templates-snap.yaml
+++ b/jjb/edgex-templates-snap.yaml
@@ -48,7 +48,7 @@
       - edgex-snap-wrapper
 
     publishers:
-      - lf-infra-publish
+      - edgex-infra-publish
       - edgex-jenkins-alerts
 
 - snap_verify_boiler_plate: &snap_verify_boiler_plate

--- a/shell/edgex-infra-ship-logs.sh
+++ b/shell/edgex-infra-ship-logs.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo "---> edgex-infra-ship-logs.sh"
+
+ARCH=$(uname -m)
+env | grep -v PATH > .env
+docker container run \
+  --privileged \
+  --rm \
+  --env-file=.env \
+  -u 0:0 \
+  -v $WORKSPACE:$WORKSPACE \
+  -v ${WORKSPACE}@tmp:${WORKSPACE}@tmp \
+  -v /home/jenkins:/home/jenkins \
+  -e SERVER_ID=logs \
+  nexus3.edgexfoundry.org:10003/edgex-lftools-log-publisher:${ARCH} \
+  sh -c "sh global-jjb/shell/create-netrc.sh && \
+         sh global-jjb/shell/logs-deploy.sh && \
+         sh global-jjb/shell/logs-clear-credentials.sh"
+exit 0


### PR DESCRIPTION
Optimized the LFtools log publishing process for all edgex freestyle jobs; the jobs have been updated to leverage an lftools docker image stored in nexus to publish the build logs, use of this image eliminates the need to install python tools on every build thereby improving build times and eliminating python build messages from the logs.

During sandbox testing we witnessed an improvement in build times of approximately **~4mins** for arm-based jobs and **~1min** for x64-based jobs.

What was tested:
Tested a sampling of jobs in the Sandbox environment which included: 
- device-modbus-go-master-verify-go
- device-modbus-go-master-verify-go-arm
- docker-edgex-volume-master-verify-docker
- edgex-docs-master-verify-docs
- edgex-go-master-verify-go
- edgex-go-master-verify-go-arm
- edgex-go-snap-master-verify-snap
- edgex-ui-go-master-verify-go
- edgex-ui-go-master-verify-go-arm
- security-api-gateway-master-verify-go
- security-api-gateway-master-verify-go-arm
- support-rulesengine-master-verify-docker
- support-rulesengine-master-verify-docker-arm

Summary of changes:
- Created edgex-infra-ship-logs builder that leverages a docker image to facilitate the publishing of logs to nexus; the docker image is python3-based and comes with lftools installed, use of this image eliminates the need to install python tools for every build.
- Created edgex-infra-publish publisher which is a copy of the lf-infra-publish publisher (from lfit) except it references the edgex-infra-ship-logs builder. This was done as to eliminate the need for updating the lf-infra-publish publisher from lfit.
- Updated all edgex-templates to leverage edgex-infra-publish instead of lf-infra-publish publisher.

@jamesrgregg @ernestojeda @MightyNerdEric @iranjbar

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>