### PR TITLE
fixed bug with LFtools log publisher builder sysinfo log

### DIFF
--- a/shell/edgex-infra-ship-logs.sh
+++ b/shell/edgex-infra-ship-logs.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 echo "---> edgex-infra-ship-logs.sh"
 
+# determine location of sar standard activity daily file
+if [[ -n "$(uname -a | grep Ubuntu)" ]]; then
+    SAR_FILE='/var/log/sysstat'
+else
+    SAR_FILE='/var/log/sa'
+fi
+
 ARCH=$(uname -m)
+
 env | grep -v PATH > .env
 docker container run \
   --privileged \
@@ -11,6 +19,7 @@ docker container run \
   -v $WORKSPACE:$WORKSPACE \
   -v ${WORKSPACE}@tmp:${WORKSPACE}@tmp \
   -v /home/jenkins:/home/jenkins \
+  -v ${SAR_FILE}:/var/log/sa \
   -e SERVER_ID=logs \
   nexus3.edgexfoundry.org:10003/edgex-lftools-log-publisher:${ARCH} \
   sh -c "sh global-jjb/shell/create-netrc.sh && \


### PR DESCRIPTION
This update fixes the bug https://github.com/edgexfoundry/ci-management/issues/459

**Details:**
Updated the edgex-infra-ship-logs publisher so that it determines the sar standard system activity directory on the host then mounts it when running the lftools docker container.  lftools captures system information (sar and lscpu) and appends it to the _sys-info.log.gz file prior to pushing the log to Nexus.  In order for the container to execute lftools correctly the standard system activity file needs to be available in the container in order for sar utility to read the sar data. Note, LF leverages two agents (hosts), one that is x64-based (CentOS) and the other which is arm64-based (Ubuntu), the standard system activity file (sar) is located in a different location on these hosts, thus logic has been added to determine the host OS and file location. The lftools log publisher image is Alpine-based and expects the system activity file be located in /var/log/sa.

Note: In addition to the standard system activity file being made available to the docker container, the lftools docker image was updated to includes the sysstat and lscpu packages, a separate pull request will be submitted to the ci-build-images repository with the changes required for the lftools-log-publisher image. 

**What was tested**:
Tested a sampling of jobs in the Sandbox environment which included:

- device-modbus-go-master-verify-go
- device-modbus-go-master-verify-go-arm
- docker-edgex-volume-master-verify-docker
- edgex-docs-master-verify-docs
- edgex-go-master-verify-go
- edgex-go-master-verify-go-arm
- edgex-go-snap-master-verify-snap
- edgex-ui-go-master-verify-go
- edgex-ui-go-master-verify-go-arm
- security-api-gateway-master-verify-go
- security-api-gateway-master-verify-go-arm
- support-rulesengine-master-verify-docker
- support-rulesengine-master-verify-docker-arm

**Results**:
The following links shows system information being captured in the _sys-info.log.gz file:
https://logs.edgexfoundry.org/sandbox/vex-yul-edgex-jenkins-2/edgex-go-master-verify-go/1/_sys-info.log.gz
https://logs.edgexfoundry.org/sandbox/vex-yul-edgex-jenkins-2/edgex-ui-go-master-verify-go-arm/1/_sys-info.log.gz

@jamesrgregg @ernestojeda @MightyNerdEric 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>