### PR TITLE
Add the Jenkins Pipeline jobs for go-mod-secrets

### DIFF
--- a/jjb/go-modules/go-mod-secrets.yaml
+++ b/jjb/go-modules/go-mod-secrets.yaml
@@ -1,0 +1,16 @@
+---
+
+- project:
+    name: go-mod-secrets
+    project-name: go-mod-secrets
+    project: go-mod-secrets
+    mvn-settings: go-mod-secrets-settings
+    jenkins_file: 'Jenkinsfile'
+    status-context: '{project-name}-verify-pipeline'
+    stream: {}
+
+    jobs:
+      - '{project-name}-verify-pipeline'
+      - '{project-name}-merge-pipeline'
+      - '{project-name}-pipeline-webhooks':
+        status-context: '{project-name}-pipeline-webhooks' 


### PR DESCRIPTION
This update Adds a Jenkins Pipeline for the go-mod-secrets code repository and addresses the following issue: https://github.com/edgexfoundry/ci-management/issues/463

**Details**
- The JJB was modeled after the pipelines for the go-mod-registry and go-mod-core-contracts as suggested in the user story
- The go-mod-secrets code repository is: https://github.com/edgexfoundry/go-mod-secrets 
Updates to the go-mod-secrets code repository (including the Jenkinsfile, Dockerfile(s) and Makefile) to facilitate the Jenkins Pipeline were submitted via the following pull request:  https://github.com/edgexfoundry/go-mod-secrets/pull/12
- A LF ticket was submitted to create the corresponding Codecov token (go-mod-secrets-codecov-token) and have it added to the Sandbox and Production environment (IT-17242), the ticket has been resolved

**Testing**
We created and pushed a JJB pipeline job for go-mod-secrets to the Jenkins Sandbox environment and tested that the go-mod-secrets-verify-pipeline job executed successfully:
https://jenkins.edgexfoundry.org/sandbox/view/All/job/go-mod-secrets-verify-pipeline/

**Note**
The updates for the go-mod-secrets repository, which include the Jenkinsfile and Dockerfiles have been merged with the following PR: https://github.com/edgexfoundry/go-mod-secrets/pull/12

@jamesrgregg @ernestojeda @lranjbar @MightyNerdEric 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>