### PR TITLE
Remove invalid timeout setting

### DIFF
--- a/jjb/performance-test/performance-test.yaml
+++ b/jjb/performance-test/performance-test.yaml
@@ -13,8 +13,7 @@
           branch: 'master'
 
     jobs:
-      - 'performance-test-{stream}':
-          build-timeout: 60
+      - 'performance-test-{stream}'
       - 'performance-verify-{stream}':
           status-context: '{project-name}-{stream}-verify'
 


### PR DESCRIPTION
Remove the timeout setting which can't use on a pipeline job.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>

Fix #450 