### PR TITLE
Drop delhi snap jobs

### DIFF
--- a/jjb/edgex-go/edgex-go-snap.yaml
+++ b/jjb/edgex-go/edgex-go-snap.yaml
@@ -8,10 +8,6 @@
       - 'master':
           branch: 'master'
           snap-channel: latest/edge
-      - 'delhi':
-          branch: 'delhi'
-          build_script: 'cd snap && ./build.sh'
-          snap-channel: delhi/edge
       - 'edinburgh':
           branch: 'edinburgh'
           snap-channel: edinburgh/edge


### PR DESCRIPTION
Delhi is no longer supported as a release, so we can stop building these jobs.

Additionally, the jobs have been failing for some time due in part to a bug with the packaging that specified the master branch for docker-edgex-mongo, when it should have specified the delhi branch instead. Rather than fix that bug, we'll just stop builds for this.