### PR TITLE
edgex-templates-integration.yaml: set no security env var

### DIFF
--- a/jjb/edgex-templates-integration.yaml
+++ b/jjb/edgex-templates-integration.yaml
@@ -115,6 +115,9 @@
       - lf-provide-maven-settings:
           settings-file: '{mvn-settings}'
           global-settings-file: 'global-settings'
+      - inject:
+          properties-content: |
+            EDGEX_SECURITY_SECRET_STORE=false
       - shell: !include-raw-escape:
           - ../shell/integration-test-setup.sh
           - ../shell/integration-test-run.sh
@@ -149,6 +152,9 @@
       - lf-provide-maven-settings:
           settings-file: '{mvn-settings}'
           global-settings-file: 'global-settings'
+      - inject:
+          properties-content: |
+            EDGEX_SECURITY_SECRET_STORE=false
       - shell: !include-raw-escape:
           - ../shell/integration-test-setup.sh
       - edgex-provide-docker-cleanup


### PR DESCRIPTION
This is for the current set of blackbox tests that don't use security to hopefully work again, because there was an upstream change in edgex-go which changed the default behavior of the services to assume they need to run with security. However, these tests specifically are meant to run without security, so we need to explicitly disable the security features of EdgeX services.

Unfortunately as per @jamesrgregg standing up the environment to test the blackbox tests themselves in the sandbox is quite difficult so I didn't actually deploy anything to the sandbox to confirm this change. If after merging this change, the blackbox tests work "worse" (relative term since they're totally broken now AIUI) then I think we should just revert this PR and continue with investigations on how to unbreak the tests.