### PR TITLE
Revert "edgex-templates-integration.yaml: set no security env var"

### DIFF
--- a/jjb/edgex-templates-integration.yaml
+++ b/jjb/edgex-templates-integration.yaml
@@ -115,9 +115,6 @@
       - lf-provide-maven-settings:
           settings-file: '{mvn-settings}'
           global-settings-file: 'global-settings'
-      - inject:
-          properties-content: |
-            EDGEX_SECURITY_SECRET_STORE=false
       - shell: !include-raw-escape:
           - ../shell/integration-test-setup.sh
           - ../shell/integration-test-run.sh
@@ -152,9 +149,6 @@
       - lf-provide-maven-settings:
           settings-file: '{mvn-settings}'
           global-settings-file: 'global-settings'
-      - inject:
-          properties-content: |
-            EDGEX_SECURITY_SECRET_STORE=false
       - shell: !include-raw-escape:
           - ../shell/integration-test-setup.sh
       - edgex-provide-docker-cleanup


### PR DESCRIPTION
This reverts commit 90d226c6.  The commit this reverts was created to
modify the non-security Jenkins builds to add the
EDGEX_SECURITY_SECRET_STORE=false environment variable required to turn
off security. Unfortunately, blackbox-testing's docker-compose doesn't
take into account the Jenkins environment and this PR has no effect on
the EdgeX containers.  We're solving this via https://github.com/edgexfoundry/blackbox-testing/issues/294.
This reversion is being done to avoid future confusion around having
this environment variable set in the Jenkins build (which does nothing).

See https://github.com/edgexfoundry/blackbox-testing/issues/282

Signed-off-by: Michael W. Estrin <me@michaelestrin.com>