### PR TITLE
Add JJB for edgex-taf-common docker image build job

### DIFF
--- a/jjb/edgex-taf/edgex-taf-common.yaml
+++ b/jjb/edgex-taf/edgex-taf-common.yaml
@@ -1,0 +1,16 @@
+---
+
+- project:
+    name: edgex-taf-common
+    project-name: edgex-taf-common
+    project: edgex-taf-common
+    mvn-settings: edgex-taf-common-settings
+    jenkins_file: 'Jenkinsfile'
+    status-context: '{project-name}-verify-pipeline'
+    stream: {}
+
+    jobs:
+      - '{project-name}-verify-pipeline'
+      - '{project-name}-merge-pipeline'
+      - '{project-name}-pipeline-webhooks':
+        status-context: '{project-name}-pipeline-webhooks'


### PR DESCRIPTION
Fix #515 
This PR was used for creating an edgex-taf-common docker image build job.
@jamesrgregg Could you help review this issue?

I create another PR on edgex-taf-common which contains Jenkinsfile.
https://github.com/edgexfoundry/edgex-taf-common/pull/7