### PR TITLE
jjb/{device,ui}: add fuji branch for snaps

### DIFF
--- a/jjb/device/device-grove-c-snap.yaml
+++ b/jjb/device/device-grove-c-snap.yaml
@@ -11,6 +11,9 @@
       - 'edinburgh':
           branch: 'edinburgh'
           snap-channel: edinburgh/edge
+      - 'fuji':
+          branch: 'fuji'
+          snap-channel: fuji/edge
 
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':

--- a/jjb/device/device-modbus-go-snap.yaml
+++ b/jjb/device/device-modbus-go-snap.yaml
@@ -11,6 +11,9 @@
       - 'edinburgh':
           branch: 'edinburgh'
           snap-channel: edinburgh/edge
+      - 'fuji':
+          branch: 'fuji'
+          snap-channel: fuji/edge
 
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':

--- a/jjb/device/device-mqtt-go-snap.yaml
+++ b/jjb/device/device-mqtt-go-snap.yaml
@@ -11,6 +11,9 @@
       - 'edinburgh':
           branch: 'edinburgh'
           snap-channel: edinburgh/edge
+      - 'fuji':
+          branch: 'fuji'
+          snap-channel: fuji/edge
 
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':

--- a/jjb/ui/edgex-ui-go-snap.yaml
+++ b/jjb/ui/edgex-ui-go-snap.yaml
@@ -11,6 +11,10 @@
       - 'edinburgh':
           branch: 'edinburgh'
           snap-channel: edinburgh/edge
+      - 'fuji':
+          branch: 'fuji'
+          snap-channel: fuji/edge
+
     jobs:
      - '{project-name}-{stream}-stage-snap-arm':
          build-node: ubuntu18.04-docker-arm64-4c-2g


### PR DESCRIPTION
These snaps should also have fuji jobs running for them.

I also filed https://jira.linuxfoundation.org/servicedesk/customer/portal/2/IT-18236 to get the tracks setup from the LF on the snap store.