### PR TITLE
Add go proxy for all go jobs

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -54,6 +54,7 @@
     staging-profile-id: a004df83a6249
     mvn-staging-id: staging
     nexus-snapshot-repo: snapshots
+    go-proxy: https://nexus3.edgexfoundry.org/repository/go-proxy/
 
     # Sonarcloud
     sonarcloud_project_organization: edgexfoundry

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -133,6 +133,7 @@
             GOROOT={go-root}
             PATH={path}
             GOPATH=$HOME/$BUILD_ID/gopath
+            GOPROXY={go-proxy}
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - edgex-codecov:
@@ -169,6 +170,7 @@
             GOROOT={go-root}
             PATH={path}
             GOPATH=$HOME/$BUILD_ID/gopath
+            GOPROXY={go-proxy}
             DEPLOY_TYPE=snapshot
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -211,6 +213,7 @@
             GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
+            GOPROXY={go-proxy}
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -251,6 +254,7 @@
             GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
+            GOPROXY={go-proxy}
             DEPLOY_TYPE=snapshot
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
@@ -298,6 +302,7 @@
             GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
+            GOPROXY={go-proxy}
             DEPLOY_TYPE=staging
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
@@ -342,6 +347,7 @@
             PATH={path}
             GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
+            GOPROXY={go-proxy}
             DEPLOY_TYPE=staging
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -385,6 +391,7 @@
             GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
             GOARCH=arm64
+            GOPROXY={go-proxy}
             DEPLOY_TYPE=release
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
@@ -426,6 +433,7 @@
             PATH={path}
             GOPATH=$HOME/$BUILD_ID/gopath
             GOOS=linux
+            GOPROXY={go-proxy}
             DEPLOY_TYPE=release
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'


### PR DESCRIPTION
This will utilize our Nexus 3 server as a proxy for Go modules.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>

Successful tests:
https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-go-master-verify-go/1/
https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-go-master-verify-go-arm/1/