### PR TITLE
Add job for sync api doc to swaggerhub

### DIFF
--- a/jjb/edgex-api-doc/edgex-api-doc.yaml
+++ b/jjb/edgex-api-doc/edgex-api-doc.yaml
@@ -1,0 +1,15 @@
+---
+- project:
+    name: edgex-api-docs
+    project-name: edgex-api-docs
+    project: edgex-api-docs
+    mvn-settings: edgex-api-docs-settings
+    jenkins_file: 'Jenkinsfile'
+    stream:
+      - 'master':
+          branch: 'master'
+    status-context: '{project-name}-pipeline-swagger-{stream}'
+    jobs:
+      - '{project-name}-pipeline-swagger-{stream}'
+    views:
+      - project-view

--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -167,6 +167,89 @@
       # no reason to add github-pull-request here since it doesn't currently
       # work for merge / push
 
+- pipeline_api_docs_boiler_plate: &pipeline_api_docs_boiler_plate
+    name: pipeline_api_docs_boiler_plate
+
+    project-type: pipeline
+    concurrent: true
+    submodule-recursive: true
+    node: '{build-node}'
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+    status-context: ''
+    jenkins_file: 'Jenkinsfile'
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    properties:
+      - lf-infra-properties:
+          project: '{project}'
+          build-days-to-keep: '{build-days-to-keep}'
+      - github:
+          url: '{git-url}/{github-org}/{project}'
+      - inject:
+          properties-content: |
+            BUILD_NODE='{build-node}'
+            MVN_SETTINGS={mvn-settings}
+            SEMVER_BRANCH={branch}
+
+    parameters:
+      - string:
+          name: sha1
+          default: '*/{branch}'
+          description: |
+              GitHub PR Trigger provided parameter for specifying the commit
+              to checkout.
+
+              If using GitHub, in a manual build override with a branch path or
+              sha1 hash to a specific commit. For example: '{branch}'
+      - string:
+          name: PROJECT
+          default: '{project}'
+          description: |
+              Parameter to identify a SCM project to build. This is typically
+              the project repo path. For example: ofextensions/circuitsw
+      - string:
+          name: APIVERSION
+          default: '1.1.0'
+          description: |
+              EdgeX API release version, can't be empty
+      - string:
+          name: OASVERSION
+          default: '3.0.0'
+          description: |
+              The OpenApi Specification (OAS) version, can't be empty
+      - string:
+          name: OWNER
+          default: 'edgexfoundry1'
+          description: |
+              API owner (user or organization, case-sensitive), can't be empty
+      - bool:
+          name: ISPRIVATE
+          default: true
+          description: |
+              Defines whether the API has to be private
+
+    pipeline-scm:
+      script-path: '{jenkins_file}'
+      scm:
+        - lf-infra-github-scm:
+            url: '{git-clone-url}{github-org}/{project}'
+            refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+            branch: '$sha1'
+            submodule-recursive: '{submodule-recursive}'
+            choosing-strategy: default
+            jenkins-ssh-credential: '{jenkins-ssh-credential}'
+            submodule-disable: false
+            submodule-timeout: 10
+
+
 # Job Templates
 
 - job-template:
@@ -225,3 +308,15 @@
           global-settings-file: 'global-settings'
           settings-file: '{mvn-settings}'
       - shell: 'ls'
+
+- job-template:
+    name: '{project-name}-pipeline-swagger-{stream}'
+
+    <<: *pipeline_api_docs_boiler_plate
+
+    build-node: centos7-docker-4c-2g
+
+    builders:
+      - lf-provide-maven-settings:
+          global-settings-file: 'global-settings'
+          settings-file: '{mvn-settings}'


### PR DESCRIPTION
1. The [API docs repository](https://github.com/edgexfoundry-holding/edgex-api-docs) put on edgexfoundry-holding (for swagger investigation).
2. The [PR #3](https://github.com/edgexfoundry-holding/edgex-api-docs/pull/3) is opened for sync API docs to swagger
3. This job has to add SwaggerHub API key to credentials for the [Jenkinsfile](https://github.com/cherrycl/edgex-api-docs/blob/fb4379440500f7a89932e8987c2b8c5098fd0ca0/Jenkinsfile#L6).

Signed-off-by: Cherry Wang <cherry@iotechsys.com>