### PR TITLE
Update edgex-go template to include REPO_ROOT env variable. Fixes #547

### DIFF
--- a/jjb/edgex-go/edgex-go.yaml
+++ b/jjb/edgex-go/edgex-go.yaml
@@ -11,6 +11,7 @@
           pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
           build_script: 'make test raml_verify && make build docker'
           go-root: '/opt/go-custom/go'
+          repo-root: '$HOME/$BUILD_ID/gopath/src/github.com/edgexfoundry/{project-name}/'
       - 'fuji':
           branch: 'fuji'
           pre_build_script: !include-raw-escape: shell/install_custom_golang.sh

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -20,6 +20,7 @@
     workspace: '$HOME/$BUILD_ID/gopath/src/github.com/edgexfoundry/{project-name}/'
     go-root: /usr/local/go
     path: $PATH:$GOROOT/bin
+    repo-root: ''
 
     #####################
     # Job Configuration #
@@ -134,6 +135,7 @@
             PATH={path}
             GOPATH=$HOME/$BUILD_ID/gopath
             GOPROXY={go-proxy}
+            REPO_ROOT={repo-root}
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - edgex-codecov:
@@ -172,6 +174,7 @@
             GOPATH=$HOME/$BUILD_ID/gopath
             GOPROXY={go-proxy}
             DEPLOY_TYPE=snapshot
+            REPO_ROOT={repo-root}
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - lf-infra-create-netrc:
@@ -214,6 +217,7 @@
             GOOS=linux
             GOARCH=arm64
             GOPROXY={go-proxy}
+            REPO_ROOT={repo-root}
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -256,6 +260,7 @@
             GOARCH=arm64
             GOPROXY={go-proxy}
             DEPLOY_TYPE=snapshot
+            REPO_ROOT={repo-root}
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -304,6 +309,7 @@
             GOARCH=arm64
             GOPROXY={go-proxy}
             DEPLOY_TYPE=staging
+            REPO_ROOT={repo-root}
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -349,6 +355,7 @@
             GOOS=linux
             GOPROXY={go-proxy}
             DEPLOY_TYPE=staging
+            REPO_ROOT={repo-root}
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - lf-infra-create-netrc:
@@ -393,6 +400,7 @@
             GOARCH=arm64
             GOPROXY={go-proxy}
             DEPLOY_TYPE=release
+            REPO_ROOT={repo-root}
       - shell: '{obj:golang_arm_script}'
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
@@ -435,6 +443,7 @@
             GOOS=linux
             GOPROXY={go-proxy}
             DEPLOY_TYPE=release
+            REPO_ROOT={repo-root}
       - shell: '{obj:pre_build_script}'
       - shell: '{obj:build_script}'
       - lf-infra-create-netrc:


### PR DESCRIPTION
Tested on sandbox against targeted PR and current master tip. Should allow builds continue that don't require this variable.

Against PR-2285:
https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-go-master-verify-go/5/console

Against edgex-go master:
https://jenkins.edgexfoundry.org/sandbox/view/All/job/edgex-go-master-verify-go/6/console

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>