### PR TITLE
remove 'master stream' from JJB management

### DIFF
--- a/jjb/device/device-modbus-go.yaml
+++ b/jjb/device/device-modbus-go.yaml
@@ -9,11 +9,6 @@
     build_script: 'make build && make docker'
     cron: 'H 11 * * *'
     stream:
-      - 'master':
-          branch: 'master'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          build_script: 'make test && make build docker'
-          go-root: '/opt/go-custom/go'
       - 'fuji':
           branch: 'fuji'
           pre_build_script: !include-raw-escape: shell/install_custom_golang.sh

--- a/jjb/device/device-sdk-go.yaml
+++ b/jjb/device/device-sdk-go.yaml
@@ -9,11 +9,6 @@
     build_script: 'make build && make docker'
     cron: 'H 11 * * *'
     stream:
-      - 'master':
-          branch: 'master'
-          pre_build_script: !include-raw-escape: shell/install_custom_golang.sh
-          build_script: 'make test && make build docker'
-          go-root: '/opt/go-custom/go'
       - 'fuji':
           branch: 'fuji'
           pre_build_script: !include-raw-escape: shell/install_custom_golang.sh


### PR DESCRIPTION
Migration of JJB builds to pipelines. Related PR's are:

- https://github.com/edgexfoundry/device-modbus-go/pull/116
- https://github.com/edgexfoundry/device-sdk-go/pull/438

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>