### PR TITLE
Add shell script for posting api files to SwaggerHub

### DIFF
--- a/shell/toSwaggerHub.sh
+++ b/shell/toSwaggerHub.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+apiKey=$1
+apiFolder=$2
+apiVersion=$3
+oasVersion=$4
+isPrivate=$5
+owner=$6
+apiPath="api/openapi/"${apiFolder}
+
+for file in ${apiPath}/*.yaml; do
+    apiName="$(echo $file | cut -d "/" -f 4 | cut -d "." -f 1)"
+    echo "API_Name:"$apiName
+    apiContent="$(cat ${apiPath}/${apiName}.yaml)"
+    
+    curl -X POST "https://api.swaggerhub.com/apis/${owner}/${apiName}?isPrivate=${isPrivate}&version=${apiVersion}&oas=${oasVersion}&force=true" -H "accept:application/json" -H "Authorization:${apiKey}" -H "Content-Type:application/yaml" -d "${apiContent}"
+done


### PR DESCRIPTION
Add shell script for posting API files to SwaggerHub
The credential of SwaggerHub has added to Jenkins by LF ticket [IT-18875](https://jira.linuxfoundation.org/servicedesk/customer/portal/2/IT-18875).
Fix #564 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>