### PR TITLE
Add new params for v0.43.1 of global-jjb

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -59,3 +59,9 @@
     # Sonarcloud
     sonarcloud_project_organization: edgexfoundry
     sonarcloud_api_token: 3e68831b5a5b2b70a5c6698c8f6878f251c1ee97
+
+    # Nexus3 docker registries
+    container-public-registry: docker.io
+    container-snapshot-registry: nexus3.edgexfoundry.org:10003
+    container-staging-registry: nexus3.edgexfoundry.org:10004
+    container-push-registry: '{container-staging-registry}'


### PR DESCRIPTION
The previous upgrade of global-jjb did not follow the upgrade notes.
These variables are now required.

Issue: LF-Jira RELENG-2697
Signed-off-by: Eric Ball <eball@linuxfoundation.org>