### PR TITLE
Publish v1 API to Swagger and remove some variables

### DIFF
--- a/shell/edgex-publish-swagger.sh
+++ b/shell/edgex-publish-swagger.sh
@@ -9,8 +9,8 @@ if [ -z "$ARCH" ] || [ "$ARCH" != "arm64" ] ; then
     # NOTE: APIKEY needs to be a pointer to a file with the key. This will need to be set locally from your environment or from Jenkins
     APIKEY_VALUE=`cat $APIKEY`
 
-    API_VERSION=${API_VERSION:-2.0.0}
-    API_FOLDER=${API_FOLDER:-v2}
+    # Upload both API versions,v1 and v2, to SwaggerHub
+    API_FOLDERS="v1 v2"
     SWAGGER_DRY_RUN=${SWAGGER_DRY_RUN:-false}
 
     SCRIPTS_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
@@ -21,7 +21,11 @@ if [ -z "$ARCH" ] || [ "$ARCH" != "arm64" ] ; then
     ISPRIVATE=true
     OWNER='EdgeXFoundry1'
 
-    publishToSwagger "${APIKEY_VALUE}" "${API_FOLDER}" "${API_VERSION}" "${OASVERSION}" "${ISPRIVATE}" "${OWNER}" "${SWAGGER_DRY_RUN}"
+    for API_FOLDER in ${API_FOLDERS}; do
+        echo "=== Publish ${API_FOLDER} API ==="
+        publishToSwagger "${APIKEY_VALUE}" "${API_FOLDER}" "${OASVERSION}" "${ISPRIVATE}" "${OWNER}" "${SWAGGER_DRY_RUN}"
+    done
+
 else
     echo "$ARCH not supported...skipping."
 fi

--- a/shell/toSwaggerHub.sh
+++ b/shell/toSwaggerHub.sh
@@ -5,15 +5,14 @@ echo "--> toSwaggerHub.sh"
 publishToSwagger() {
     apiKey=$1
     apiFolder=$2
-    apiVersion=$3
-    oasVersion=$4
-    isPrivate=$5
-    owner=$6
-    dryRun=${7:-false}
+    oasVersion=$3
+    isPrivate=$4
+    owner=$5
+    dryRun=${6:-false}
 
     apiPath="$WORKSPACE/api/openapi/"${apiFolder}
 
-    echo "[toSwaggerHub] Publishing the API Docs [${apiVersion}] to Swagger"
+    echo "[toSwaggerHub] Publishing the API Docs [${apiFolder}] to Swagger"
 
     if [ -d "$apiPath" ]; then
         for file in "${apiPath}"/*.yaml; do
@@ -23,14 +22,15 @@ publishToSwagger() {
             echo "[toSwaggerHub] Publishing API Name [$apiName]"
 
             if [ "$dryRun" == "false" ]; then
-                curl -X POST "https://api.swaggerhub.com/apis/${owner}/${apiName}?isPrivate=${isPrivate}&version=${apiVersion}&oas=${oasVersion}&force=true" \
+                curl -X POST "https://api.swaggerhub.com/apis/${owner}/${apiName}?oas=${oasVersion}&isPrivate=${isPrivate}&force=true" \
                     -H "accept:application/json" \
                     -H "Authorization:${apiKey}" \
                     -H "Content-Type:application/yaml" \
                     -d "${apiContent}"
+                echo $'\n'
             else
                 echo "[toSwaggerHub] Dry Run enabled...Simulating upload"
-                echo "curl -X POST https://api.swaggerhub.com/apis/${owner}/${apiName}?isPrivate=${isPrivate}&version=${apiVersion}&oas=${oasVersion}&force=true"
+                echo "curl -X POST https://api.swaggerhub.com/apis/${owner}/${apiName}?oas=${oasVersion}&isPrivate=${isPrivate}&force=true"
             fi
 
         done


### PR DESCRIPTION
1. Remove isPrivate and API_VERSION variables. The API_VERSION will get from API file directly, and set the API to public when sending the API to SwaggerHub.
2. Publish v1 API to SwaggerHub.
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
Fix #579 