### PR TITLE
Change execute time to 0400 UTC for blackbox-testing job

### DIFF
--- a/jjb/edgex-templates-integration.yaml
+++ b/jjb/edgex-templates-integration.yaml
@@ -87,7 +87,7 @@
       - github
       - pollscm:
           cron: ''
-      - timed: 'H 12 * * *'
+      - timed: 'H 04 * * *'
 
 # Job Templates
 


### PR DESCRIPTION
Change execute time to 0400 UTC for all blackbox-testing jobs
Signed-off-by: Cherry Wang <cherry@iotechsys.com>
Fix #586 