### PR TITLE
Update integration-test to use compose container

### DIFF
--- a/shell/integration-test-run.sh
+++ b/shell/integration-test-run.sh
@@ -2,10 +2,16 @@
 # Ensure we fail the job if any steps fail
 set -e -o pipefail
 
-cd bin; bash ./run.sh -all postman-integration-test
+docker run --rm -v $PWD:$PWD:rw,z -w $PWD -v /var/run/docker.sock:/var/run/docker.sock --privileged \
+-e SECURITY_SERVICE_NEEDED=$SECURITY_SERVICE_NEEDED -e DATABASE=$DATABASE --env-file $ENV_FILE \
+-e docker_compose_test_tools=$docker_compose_test_tools \
+--entrypoint /bin/sh $DOCKER_COMPOSE bin/run.sh -all postman-integration-test
+
+sudo chown jenkins:jenkins bin/testResult
+sudo chmod g+w bin/testResult
 
 if [ "${DATABASE:=redis}" = redis ]; then
-     sed -E -i "s/testsuite name=\"/testsuite name=\"redis_/" $(ls testResult/*.xml)
+     sed -E -i "s/testsuite name=\"/testsuite name=\"redis_/" $(ls bin/testResult/*.xml)
 else
-     sed -E -i "s/testsuite name=\"/testsuite name=\"mongo_/" $(ls testResult/*.xml)
+     sed -E -i "s/testsuite name=\"/testsuite name=\"mongo_/" $(ls bin/testResult/*.xml)
 fi


### PR DESCRIPTION
Change to use docker-compose docker container instead of using apt install docker-compose, because apt causes build failure sometimes.

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
Fix https://github.com/edgexfoundry/blackbox-testing/issues/423
## Sandbox Testing
Test Links :
All blackbox-testing fuji and master branch 
https://jenkins.edgexfoundry.org/sandbox/view/All/

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

