### PR TITLE
Remove master stage snap jobs

### DIFF
--- a/jjb/edgex-go/edgex-go-snap-legacy.yaml
+++ b/jjb/edgex-go/edgex-go-snap-legacy.yaml
@@ -1,16 +1,18 @@
 ---
 - project:
-    name: edgex-go-snap
-    project-name: edgex-go-snap
+    name: edgex-go-snap-legacy
+    project-name: edgex-go-snap-legacy
     project: edgex-go
     mvn-settings: edgex-go-settings
     stream:
-      - 'master':
-          branch: 'master'
-          snap-channel: latest/edge
+      - 'fuji':
+          branch: 'fuji'
+          snap-channel: fuji/edge
 
     jobs:
-     - '{project-name}-release-snap':
+     - '{project-name}-{stream}-stage-snap-arm':
+         build-node: ubuntu18.04-docker-arm64-4c-16g
+     - '{project-name}-{stream}-stage-snap':
          build-node: centos7-docker-4c-2g
      - '{project-name}-{stream}-verify-snap-arm':
          build-node: ubuntu18.04-docker-arm64-4c-16g


### PR DESCRIPTION
This PR removes two jobs in favor of the new job being created in the cd-mangement repository: https://github.com/edgexfoundry/cd-management/pull/7.

- edgex-go-snap-master-verify-snap
- edgex-go-snap-master-verify-snap-arm

I could not figure out how to easily preserve the Fuji stage jobs without moving the Fuji stream to a separate file: jjb/edgex-go/edgex-go-snap-legacy.yaml. If there is a way to have jobs only for a specific stream without splitting it into another file, please let me know.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

