### PR TITLE
first pass at generating multi-architecture docker images

### DIFF
--- a/shell/edgexfoundry-go-docker-push.sh
+++ b/shell/edgexfoundry-go-docker-push.sh
@@ -32,6 +32,11 @@ for image in "${images[@]}"; do
     'snapshot' )
       docker tag $image_id "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}"$ARCH:$GIT_SHA-$VERSION
       docker push "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}"$ARCH:$GIT_SHA-$VERSION
+      docker manifest create "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}":$GIT_SHA-$VERSION $ARCH
+      docker manifest annotate "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}":$GIT_SHA-$VERSION \
+        "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}"$ARCH:$GIT_SHA-$VERSION \
+        --os linux --arch $ARCH
+      docker manifest push "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10003}"
       ;;
     'staging' )
       docker tag $image_id "${image_repo/edgexfoundry/nexus3.edgexfoundry.org:10004}"$ARCH:$GIT_SHA-$VERSION


### PR DESCRIPTION
## PR Checklist
Docker image building / creation seems to happen in numerous places. This is a first pass at updating one location to use docker manifests to make multi-architecture images forgoing the buildkit requirement.

pseudocode:
```
docker tag $(REGISTRY)/$(IMAGE):$(ARCH)-$(VERSION)
docker push $(REGISTRY)/$(IMAGE):$(ARCH)-$(VERSION)
docker manifest create $(REGISTRY)/$(IMAGE):$(VERSION)
docker manifest annotate $(REGISTRY)/$(IMAGE):$(VERSION) $(REGISTRY)/$(IMAGE):$(ARCH)-$(VERSION) --os linux --arch $(ARCH)
docker manifest push $(REGISTRY)/$(IMAGE):$(VERSION)
```
end result is `docker run $(REGISTRY)/$(IMAGE):$(VERSION)` will give the proper architecture without needing it explicitly specified

Redis screenshot as an example

![image](https://user-images.githubusercontent.com/697188/85455796-48c22580-b56c-11ea-9b14-67f5b4fe450a.png)

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

