### PR TITLE
chore: remove legacy snap jobs

### DIFF
--- a/jjb/device/device-grove-c-snap.yaml
+++ b/jjb/device/device-grove-c-snap.yaml
@@ -10,15 +10,5 @@
           snap-channel: latest/edge
 
     jobs:
-     - '{project-name}-{stream}-stage-snap-arm':
-         build-node: ubuntu18.04-docker-arm64-4c-16g
      - '{project-name}-release-snap':
          build-node: centos7-docker-4c-2g
-     - '{project-name}-{stream}-stage-snap':
-         build-node: centos7-docker-4c-2g
-     - '{project-name}-{stream}-verify-snap-arm':
-         build-node: ubuntu18.04-docker-arm64-4c-16g
-         status-context: '{project-name}-{stream}-verify-arm'
-     - '{project-name}-{stream}-verify-snap':
-         build-node: centos7-docker-4c-2g
-         status-context: '{project-name}-{stream}-verify'

--- a/jjb/edgex-go/edgex-go.yaml
+++ b/jjb/edgex-go/edgex-go.yaml
@@ -12,12 +12,6 @@
     jobs:
      - '{project-name}-release-snap':
          build-node: centos7-docker-4c-2g
-     - '{project-name}-{stream}-verify-snap-arm':
-         build-node: ubuntu18.04-docker-arm64-4c-16g
-         status-context: '{project-name}-{stream}-verify-arm'
-     - '{project-name}-{stream}-verify-snap':
-         build-node: centos7-docker-4c-2g
-         status-context: '{project-name}-{stream}-verify'
 
     views:
       - project-view

--- a/jjb/ui/edgex-ui-go-snap.yaml
+++ b/jjb/ui/edgex-ui-go-snap.yaml
@@ -10,15 +10,5 @@
           snap-channel: latest/edge
 
     jobs:
-     - '{project-name}-{stream}-stage-snap-arm':
-         build-node: ubuntu18.04-docker-arm64-4c-16g
      - '{project-name}-release-snap':
          build-node: centos7-docker-4c-2g
-     - '{project-name}-{stream}-stage-snap':
-         build-node: centos7-docker-4c-2g
-     - '{project-name}-{stream}-verify-snap-arm':
-         build-node: ubuntu18.04-docker-arm64-4c-16g
-         status-context: '{project-name}-{stream}-verify-arm'
-     - '{project-name}-{stream}-verify-snap':
-         build-node: centos7-docker-4c-2g
-         status-context: '{project-name}-{stream}-verify'


### PR DESCRIPTION
This PR will remove the legacy snap jobs no longer in use. I am keeping the manual release snap jobs for now just in case they need to be used for the Hanoi release.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other... Please describe: Cleanup

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

