### PR TITLE
feat: add new ubuntu-18.04-amd64 platform

### DIFF
--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -32,4 +32,5 @@
     platforms:
       - centos-7
       - ubuntu-18.04-arm64
+      - ubuntu-18.04-amd64
     templates: docker


### PR DESCRIPTION
Add a new amd64 Ubuntu 18.04 platform for snap builds.
This is the first step required to resolve issue #619.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [NA] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number: 619

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
This is the first step required to resolve issue #619. Once this lands, a new image will be produced and the next PR will add a new config which references the new image. The last step involves modifying the amd64 snap build job to reference this new platform.

## Other information

