### PR TITLE
fix: rm -amd64 suffix from new ubuntu node

### DIFF
--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -32,5 +32,5 @@
     platforms:
       - centos-7
       - ubuntu-18.04-arm64
-      - ubuntu-18.04-amd64
+      - ubuntu-18.04
     templates: docker


### PR DESCRIPTION
Remove the -amd64 suffix from the new amd64
Ubuntu build node, as amd64 is the default
architecture, and thus isn't part of the name.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
This PR part of the overall fix for issue #619. The previous PR specified an invalid platform name, which this PR addresses. 

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information

