### PR TITLE
Add docker proxy settings to packer builds

### DIFF
--- a/packer/provision/local-docker.yaml
+++ b/packer/provision/local-docker.yaml
@@ -73,7 +73,7 @@
             dest: '/opt'
             creates: '/opt/golang/111'
             remote_src: true
-          become: true       
+          become: true
 
     - name: 'Install Glide {{glide_version}}'
       block:
@@ -130,3 +130,10 @@
         state: present
       when: ansible_distribution == 'Ubuntu'
       become: true
+
+    - name: 'Set docker proxy'
+      lineinfile:
+        dest: /etc/docker/daemon.json
+        line: '  "registry-mirrors": ["https://nexus3.edgexfoundry.org"],'
+        state: present
+        insertafter: '{'


### PR DESCRIPTION
This will enable the nexus3 docker proxy when the builder spins up.

Issue: LF-Jira IT-20979
Signed-off-by: Eric Ball <eball@linuxfoundation.org>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

