### PR TITLE
Switch to v3-standard-4

### DIFF
--- a/jenkins-config/clouds/openstack/Primary/ubuntu18.04-docker-arm64-4c-16g.cfg
+++ b/jenkins-config/clouds/openstack/Primary/ubuntu18.04-docker-arm64-4c-16g.cfg
@@ -1,3 +1,2 @@
 IMAGE_NAME=ZZCI - Ubuntu 18.04 - docker - arm64 - 20210129-194716.580
-HARDWARE_ID=v2-standard-4
-VOLUME_SIZE=40
+HARDWARE_ID=v3-standard-4


### PR DESCRIPTION
The V3 instance sizes is now supported for ARM instances as well
so you can make use of that, it also includes 80G of local disk out
of the box which is more than the 40G you were provisioning in
block storage.

This will also help fix some scheduling issues because of the
dependency of V2 instances with ARM.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

