### PR TITLE
Chore: Remove the cfg-merge job

### DIFF
--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -1,7 +1,11 @@
 ---
 - project:
     jobs:
-      - '{project-name}-github-ci-jobs'
+      - github-jenkins-cfg-verify
+      - github-jenkins-sandbox-cleanup
+      - github-jjb-deploy-job
+      - github-jjb-merge
+      - github-jjb-verify
       - github-packer-verify
 
     name: ci-management-jobs


### PR DESCRIPTION
With the advent of using JCasC for managing the Jenkins configuration,
the ci-management-jenkins-cfg-merge job is now redundant and potentially
even harmful as it can still break easily if the OpenStack plugin
changes.

To avoid this, we expand the basic github-ci-jobs group and exclude the
cfg-merge job specifically

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
