### PR TITLE
CI: Set github-org as project param

### DIFF
--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -13,6 +13,7 @@
     project-name: ci-management
     build-node: centos7-builder-2c-1g
     build-timeout: 20
+    github-org: edgexfoundry
 
 - project:
     name: builder-openstack
@@ -22,6 +23,7 @@
     project: ci-management
     project-name: ci-management
     build-node: centos7-builder-2c-1g
+    github-org: edgexfoundry
 
     jenkins-urls: >
         https://jenkins.edgexfoundry.org

--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -9,6 +9,7 @@
     project-name: ci-management
     branch: master
     archive-artifacts: '**/*.log'
+    github-org: edgexfoundry
 
     build-node: centos7-builder-2c-1g
     build-timeout: 90
@@ -27,6 +28,7 @@
     project-name: ci-management
     branch: master
     archive-artifacts: '**/*.log'
+    github-org: edgexfoundry
 
     build-node: centos7-builder-2c-1g
     build-timeout: 90

--- a/jjb/device/device-grove-c-snap.yaml
+++ b/jjb/device/device-grove-c-snap.yaml
@@ -4,6 +4,7 @@
     project-name: device-grove-c-snap
     project: device-grove-c
     mvn-settings: device-grove-c-settings
+    github-org: edgexfoundry
     stream:
       - 'master':
           branch: 'master'

--- a/jjb/edgex-go/edgex-go.yaml
+++ b/jjb/edgex-go/edgex-go.yaml
@@ -4,6 +4,7 @@
     project-name: edgex-go-snap
     project: edgex-go
     mvn-settings: edgex-go-settings
+    github-org: edgexfoundry
     stream:
       - 'master':
           branch: 'master'

--- a/jjb/edgex-templates-docker.yaml
+++ b/jjb/edgex-templates-docker.yaml
@@ -2,7 +2,7 @@
 ###########
 # ANCHORS #
 ###########
-- docker_job_boiler_plate: &docker_job_boiler_plate
+- _docker_job_boiler_plate: &docker_job_boiler_plate
     name: docker_job-boiler-plate
 
     project-type: freestyle
@@ -51,7 +51,7 @@
     publishers:
       - edgex-infra-publish
 
-- docker_verify_boiler_plate: &docker_verify_boiler_plate
+- _docker_verify_boiler_plate: &docker_verify_boiler_plate
     name: docker_verify_boiler_plate
 
     concurrent: true
@@ -79,7 +79,7 @@
             - '{branch}'
 
 
-- docker_merge_boiler_plate: &docker_merge_boiler_plate
+- _docker_merge_boiler_plate: &docker_merge_boiler_plate
     name: docker_merge_boiler_plate
 
     scm:

--- a/jjb/edgex-templates-docs.yaml
+++ b/jjb/edgex-templates-docs.yaml
@@ -1,6 +1,6 @@
 ---
 # Job definition Anchors
-- docs_job_boiler_plate: &docs_job_boiler_plate
+- _docs_job_boiler_plate: &docs_job_boiler_plate
     name: docs_job-boiler-plate
 
     project-type: freestyle
@@ -49,7 +49,7 @@
       - edgex-infra-publish
       - edgex-jenkins-alerts
 
-- docs_verify_boiler_plate: &docs_verify_boiler_plate
+- _docs_verify_boiler_plate: &docs_verify_boiler_plate
     name: docs_verify_boiler_plate
 
     concurrent: true
@@ -76,7 +76,7 @@
           white-list-target-branches:
             - '{branch}'
 
-- docs_merge_boiler_plate: &docs_merge_boiler_plate
+- _docs_merge_boiler_plate: &docs_merge_boiler_plate
     name: docs_merge_boiler_plate
 
     scm:

--- a/jjb/edgex-templates-go.yaml
+++ b/jjb/edgex-templates-go.yaml
@@ -1,6 +1,6 @@
 ---
 # Job definition Anchors
-- go_job_boiler_plate: &go_job_boiler_plate
+- _go_job_boiler_plate: &go_job_boiler_plate
     name: go_job-boiler-plate
 
     project-type: freestyle
@@ -53,7 +53,7 @@
       - edgex-infra-publish
       - edgex-jenkins-alerts
 
-- go_verify_boiler_plate: &go_verify_boiler_plate
+- _go_verify_boiler_plate: &go_verify_boiler_plate
     name: go_verify_boiler_plate
 
     concurrent: true
@@ -81,7 +81,7 @@
             - '{branch}'
 
 
-- go_merge_boiler_plate: &go_merge_boiler_plate
+- _go_merge_boiler_plate: &go_merge_boiler_plate
     name: go_merge_boiler_plate
 
     scm:

--- a/jjb/edgex-templates-java.yaml
+++ b/jjb/edgex-templates-java.yaml
@@ -1,6 +1,6 @@
 ---
 # Job definition Anchors
-- job_boiler_plate: &job_boiler_plate
+- _job_boiler_plate: &job_boiler_plate
     name: job-boiler-plate
 
     project-type: freestyle
@@ -39,7 +39,7 @@
     publishers:
       - edgex-infra-publish
 
-- verify_boiler_plate: &verify_boiler_plate
+- _verify_boiler_plate: &verify_boiler_plate
     name: verify_boiler_plate
 
     concurrent: true
@@ -67,7 +67,7 @@
             - '{branch}'
 
 
-- merge_boiler_plate: &merge_boiler_plate
+- _merge_boiler_plate: &merge_boiler_plate
     name: merge_boiler_plate
 
     scm:

--- a/jjb/edgex-templates-performance.yaml
+++ b/jjb/edgex-templates-performance.yaml
@@ -1,6 +1,6 @@
 ---
 # Job definition Anchors
-- performance_job_boiler_plate: &performance_job_boiler_plate
+- _performance_job_boiler_plate: &performance_job_boiler_plate
     name: performance_job-boiler-plate
 
     project-type: pipeline
@@ -72,7 +72,7 @@
           description: |
               Trigger JMeter script, can't be empty
 
-- performance_verify_boiler_plate: &performance_verify_boiler_plate
+- _performance_verify_boiler_plate: &performance_verify_boiler_plate
     name: performance_verify_boiler_plate
 
     scm:
@@ -86,7 +86,7 @@
           submodule-disable: false
           submodule-timeout: 10
 
-- performance_test_boiler_plate: &performance_test_boiler_plate
+- _performance_test_boiler_plate: &performance_test_boiler_plate
     name: performance_test_boiler_plate
 
     scm:

--- a/jjb/edgex-templates-pipeline.yaml
+++ b/jjb/edgex-templates-pipeline.yaml
@@ -1,6 +1,6 @@
 ---
 # Job definition Anchors
-- pipeline_job_boiler_plate: &pipeline_job_boiler_plate
+- _pipeline_job_boiler_plate: &pipeline_job_boiler_plate
     name: pipeline_job_boiler_plate
 
     project-type: pipeline
@@ -47,7 +47,7 @@
 
     publishers: {}
 
-- pipeline_verify_boiler_plate: &pipeline_verify_boiler_plate
+- _pipeline_verify_boiler_plate: &pipeline_verify_boiler_plate
     name: pipeline_verify_boiler_plate
     pipeline-scm:
       script-path: '{jenkins_file}'
@@ -77,7 +77,7 @@
             - '{branch}'
 
 
-- pipeline_merge_boiler_plate: &pipeline_merge_boiler_plate
+- _pipeline_merge_boiler_plate: &pipeline_merge_boiler_plate
     name: pipeline_merge_boiler_plate
     pipeline-scm:
       script-path: '{jenkins_file}'
@@ -99,7 +99,7 @@
       # no reason to add github-pull-request here since it doesn't currently
       # work for merge / push
 
-- pipeline_webhooks_boiler_plate: &pipeline_webhooks_boiler_plate
+- _pipeline_webhooks_boiler_plate: &pipeline_webhooks_boiler_plate
     # Freestyle job to have jenkins create and maintain the github push
     # webhook. Currently the github jenkins plugin cannot create the push
     # webhook using the pipeline scm section of the job.

--- a/jjb/edgex-templates-snap.yaml
+++ b/jjb/edgex-templates-snap.yaml
@@ -1,6 +1,6 @@
 ---
 # Job definition Anchors
-- snap_job_boiler_plate: &snap_job_boiler_plate
+- _snap_job_boiler_plate: &snap_job_boiler_plate
     name: snap_job-boiler-plate
 
     project-type: freestyle
@@ -51,7 +51,7 @@
       - edgex-infra-publish
       - edgex-jenkins-alerts
 
-- snap_verify_boiler_plate: &snap_verify_boiler_plate
+- _snap_verify_boiler_plate: &snap_verify_boiler_plate
     name: snap_verify_boiler_plate
 
     concurrent: true
@@ -67,7 +67,7 @@
           submodule-disable: false
           submodule-timeout: 10
 
-- snap_merge_boiler_plate: &snap_merge_boiler_plate
+- _snap_merge_boiler_plate: &snap_merge_boiler_plate
     name: snap_merge_boiler_plate
 
     scm:

--- a/jjb/performance-test/performance-test.yaml
+++ b/jjb/performance-test/performance-test.yaml
@@ -8,6 +8,7 @@
     mvn-settings: performance-test-settings
     build-timeout: 30
     jenkins_file: 'Jenkinsfile'
+    github-org: edgexfoundry
     stream:
       - 'master':
           branch: 'master'

--- a/jjb/ui/edgex-ui-go-snap.yaml
+++ b/jjb/ui/edgex-ui-go-snap.yaml
@@ -4,6 +4,7 @@
     project-name: edgex-ui-go-snap
     project: edgex-ui-go
     mvn-settings: edgex-ui-go-settings
+    github-org: edgexfoundry
     stream:
       - 'master':
           branch: 'master'


### PR DESCRIPTION
With the latest changes to the YAML parser in JJB 5x does not allow the defining a parameter when the value is trying to use itself.

Error:
lf-ci-jobs.yaml:27:18: While formatting string '{github-org}':
   Missing parameter: 'github-org' github-org: "{github-org}"

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

