### PR TITLE
ci: Set var for packer-verify to use correct file

### DIFF
--- a/jjb/ci-management/ci-management.yaml
+++ b/jjb/ci-management/ci-management.yaml
@@ -14,6 +14,7 @@
     build-node: ubuntu20.04-docker-2c-8g
     build-timeout: 20
     github-org: edgexfoundry
+    packer-cloud-settings: packer-cloud-env-hcl
 
 - project:
     name: builder-openstack


### PR DESCRIPTION
Although the platform-specific jobs in packer.yaml already have this set, the more general-purpose verify job does not. Setting this var only affects the job that uses it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

