### PR TITLE
ci: Switch from deprecated "include-raw" jjb macro

### DIFF
--- a/jjb/edgex-macros.yaml
+++ b/jjb/edgex-macros.yaml
@@ -45,7 +45,7 @@
           files:
             - file-id: 'jenkins-log-archives-settings'
               variable: 'SETTINGS_FILE'
-      - shell: !include-raw:
+      - shell: !include-raw-verbatim:
           - ../shell/edgex-infra-ship-logs.sh
       - description-setter:
           regexp: '^Build logs: .*'


### PR DESCRIPTION
The "include-raw" directive is deprecated and should be replaced with "include-raw-expand". However, the slightly different behavior of these import directives requires us to use the newer version of "include-raw-escape" instead, which is "include-raw-verbatim".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing
Test Links :

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

